### PR TITLE
feat: add support for assuming a role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 
 # Editors
 .vscode
+.idea
 
 # Logs
 logs

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: "Whether to set the AWS account ID for these credentials as a secret value, so that it is masked in logs. Valid values are 'true' and 'false'. Defaults to true"
     required: false
   role-to-assume:
-    description: "Use the provided credentials to assume a role rather than persisting the credentials directly"
+    description: "Use the provided credentials to assume a Role and output the assumed credentials for that Role rather than the provided credentials"
     required: false
   role-duration-seconds:
     description: "Role duration in seconds (default: 6 hours)"

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,12 @@ inputs:
   mask-aws-account-id:
     description: "Whether to set the AWS account ID for these credentials as a secret value, so that it is masked in logs. Valid values are 'true' and 'false'. Defaults to true"
     required: false
+  role-to-assume:
+    description: "Use the provided credentials to assume a role rather than persisting the credentials directly"
+    required: false
+  role-duration-seconds:
+    description: "Role duration in seconds (default: 6 hours)"
+    required: false
 outputs:
   aws-account-id:
     description: 'The AWS account ID for the provided credentials'

--- a/index.js
+++ b/index.js
@@ -101,7 +101,13 @@ async function run() {
     }
   }
   catch (error) {
-    core.setFailed(error.message);
+    const inGitHubAction = process.env.GITHUB_ACTIONS || false;
+
+    if(inGitHubAction) {
+      core.setFailed(error.message);
+    }else{
+      throw(error)
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,24 @@ async function assumeRole(params) {
   });
 }
 
+function exportCredentials(params){
+  const {accessKeyId, secretAccessKey, sessionToken} = params;
+
+  // AWS_ACCESS_KEY_ID:
+  // Specifies an AWS access key associated with an IAM user or role
+  core.exportVariable('AWS_ACCESS_KEY_ID', accessKeyId);
+
+  // AWS_SECRET_ACCESS_KEY:
+  // Specifies the secret key associated with the access key. This is essentially the "password" for the access key.
+  core.exportVariable('AWS_SECRET_ACCESS_KEY', secretAccessKey);
+
+  // AWS_SESSION_TOKEN:
+  // Specifies the session token value that is required if you are using temporary security credentials.
+  if (sessionToken) {
+    core.exportVariable('AWS_SESSION_TOKEN', sessionToken);
+  }
+}
+
 async function run() {
   try {
     // Get inputs
@@ -63,26 +81,15 @@ async function run() {
 
     // Get role credentials if configured to do so
     if (roleToAssume) {
-      const {accessKeyId, secretAccessKey, sessionToken} = await assumeRole(
+      const roleCredentials = await assumeRole(
           {accessKeyId, secretAccessKey, sessionToken, region, roleToAssume, roleDurationSeconds}
       );
+      exportCredentials(roleCredentials);
+    } else {
+      exportCredentials({accessKeyId, secretAccessKey, sessionToken})
     }
 
     // Configure the AWS CLI and AWS SDKs using environment variables
-
-    // AWS_ACCESS_KEY_ID:
-    // Specifies an AWS access key associated with an IAM user or role
-    core.exportVariable('AWS_ACCESS_KEY_ID', accessKeyId);
-
-    // AWS_SECRET_ACCESS_KEY:
-    // Specifies the secret key associated with the access key. This is essentially the "password" for the access key.
-    core.exportVariable('AWS_SECRET_ACCESS_KEY', secretAccessKey);
-
-    // AWS_SESSION_TOKEN:
-    // Specifies the session token value that is required if you are using temporary security credentials.
-    if (sessionToken) {
-      core.exportVariable('AWS_SESSION_TOKEN', sessionToken);
-    }
 
     // AWS_DEFAULT_REGION and AWS_REGION:
     // Specifies the AWS Region to send requests to

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ async function assumeRole(params) {
   const sts = new aws.STS({accessKeyId, secretAccessKey, sessionToken, region});
   const {GITHUB_REPOSITORY, GITHUB_WORKFLOW, GITHUB_ACTION, GITHUB_ACTOR, GITHUB_REF, GITHUB_SHA} = process.env;
 
-  for (var required in [roleToAssume, roleDurationSeconds, accessKeyId, secretAccessKey, region, GITHUB_REPOSITORY, GITHUB_WORKFLOW, GITHUB_ACTION, GITHUB_ACTOR, GITHUB_REF, GITHUB_SHA]) {
+  for (const required in [roleToAssume, roleDurationSeconds, accessKeyId, secretAccessKey, region, GITHUB_REPOSITORY, GITHUB_WORKFLOW, GITHUB_ACTION, GITHUB_ACTOR, GITHUB_REF, GITHUB_SHA]) {
     assert(required, 'Missing required value. Are you running in GitHub Actions?');
   }
 

--- a/index.js
+++ b/index.js
@@ -101,13 +101,14 @@ async function run() {
     }
   }
   catch (error) {
-    const inGitHubAction = process.env.GITHUB_ACTIONS || false;
+    core.setFailed(error.message);
 
-    if(inGitHubAction) {
-      core.setFailed(error.message);
-    }else{
+    const suppressStackTrace = process.env.DO_NOT_SUPPRESS_STACK_TRACE;
+
+    if (suppressStackTrace === 'true') {
       throw(error)
     }
+
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -118,9 +118,9 @@ async function run() {
   catch (error) {
     core.setFailed(error.message);
 
-    const suppressStackTrace = process.env.DO_NOT_SUPPRESS_STACK_TRACE;
+    const showStackTrace = process.env.SHOW_STACK_TRACE;
 
-    if (suppressStackTrace === 'true') {
+    if (showStackTrace === 'true') {
       throw(error)
     }
 

--- a/index.test.js
+++ b/index.test.js
@@ -77,6 +77,7 @@ describe('Configure AWS Credentials', () => {
 
     test('exports env vars', async () => {
         await run();
+        expect(mockStsAssumeRole).toHaveBeenCalledTimes(0);
         expect(core.exportVariable).toHaveBeenCalledTimes(5);
         expect(core.exportVariable).toHaveBeenCalledWith('AWS_ACCESS_KEY_ID', FAKE_ACCESS_KEY_ID);
         expect(core.exportVariable).toHaveBeenCalledWith('AWS_SECRET_ACCESS_KEY', FAKE_SECRET_ACCESS_KEY);
@@ -94,6 +95,7 @@ describe('Configure AWS Credentials', () => {
             .mockImplementation(mockGetInput(mockInputs));
 
         await run();
+        expect(mockStsAssumeRole).toHaveBeenCalledTimes(0);
         expect(core.exportVariable).toHaveBeenCalledTimes(4);
         expect(core.exportVariable).toHaveBeenCalledWith('AWS_ACCESS_KEY_ID', FAKE_ACCESS_KEY_ID);
         expect(core.exportVariable).toHaveBeenCalledWith('AWS_SECRET_ACCESS_KEY', FAKE_SECRET_ACCESS_KEY);
@@ -110,6 +112,7 @@ describe('Configure AWS Credentials', () => {
             .mockImplementation(mockGetInput(mockInputs));
 
         await run();
+        expect(mockStsAssumeRole).toHaveBeenCalledTimes(0);
         expect(core.exportVariable).toHaveBeenCalledTimes(4);
         expect(core.exportVariable).toHaveBeenCalledWith('AWS_ACCESS_KEY_ID', FAKE_ACCESS_KEY_ID);
         expect(core.exportVariable).toHaveBeenCalledWith('AWS_SECRET_ACCESS_KEY', FAKE_SECRET_ACCESS_KEY);
@@ -135,6 +138,7 @@ describe('Configure AWS Credentials', () => {
             .mockImplementation(mockGetInput(ASSUME_ROLE_INPUTS));
 
         await run();
+        expect(mockStsAssumeRole).toHaveBeenCalledTimes(1);
         expect(core.exportVariable).toHaveBeenCalledTimes(5);
         expect(core.exportVariable).toHaveBeenCalledWith('AWS_ACCESS_KEY_ID', FAKE_STS_ACCESS_KEY_ID);
         expect(core.exportVariable).toHaveBeenCalledWith('AWS_SECRET_ACCESS_KEY', FAKE_STS_SECRET_ACCESS_KEY);

--- a/index.test.js
+++ b/index.test.js
@@ -12,6 +12,7 @@ const FAKE_STS_SECRET_ACCESS_KEY = 'STS-AWS-SECRET-ACCESS-KEY';
 const FAKE_STS_SESSION_TOKEN = 'STS-AWS-SESSION-TOKEN';
 const FAKE_REGION = 'fake-region-1';
 const FAKE_ACCOUNT_ID = '123456789012';
+const ROLE_NAME = 'MY-ROLE';
 
 function mockGetInput(requestResponse) {
     return function (name, options) { // eslint-disable-line no-unused-vars
@@ -28,6 +29,7 @@ const DEFAULT_INPUTS = {
     'aws-region': FAKE_REGION,
     'mask-aws-account-id': 'TRUE'
 };
+const ASSUME_ROLE_INPUTS = {...REQUIRED_INPUTS, 'role-to-assume': ROLE_NAME};
 
 const mockStsCallerIdentity = jest.fn();
 const mockStsAssumeRole = jest.fn();
@@ -125,6 +127,22 @@ describe('Configure AWS Credentials', () => {
         await run();
 
         expect(core.setFailed).toBeCalled();
+    });
+
+    test('basic role assumption', async () => {
+        core.getInput = jest
+            .fn()
+            .mockImplementation(mockGetInput(ASSUME_ROLE_INPUTS));
+
+        await run();
+        expect(core.exportVariable).toHaveBeenCalledTimes(5);
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_ACCESS_KEY_ID', FAKE_STS_ACCESS_KEY_ID);
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_SECRET_ACCESS_KEY', FAKE_STS_SECRET_ACCESS_KEY);
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_SESSION_TOKEN', FAKE_STS_SESSION_TOKEN);
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_DEFAULT_REGION', FAKE_REGION);
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_REGION', FAKE_REGION);
+        expect(core.setOutput).toHaveBeenCalledWith('aws-account-id', FAKE_ACCOUNT_ID);
+        expect(core.setSecret).toHaveBeenCalledWith(FAKE_ACCOUNT_ID);
     });
 
 });

--- a/index.test.js
+++ b/index.test.js
@@ -15,7 +15,7 @@ const FAKE_REGION = 'fake-region-1';
 const FAKE_ACCOUNT_ID = '123456789012';
 const ROLE_NAME = 'MY-ROLE';
 const ENVIRONMENT_VARIABLE_OVERRIDES = {
-    DO_NOT_SUPPRESS_STACK_TRACE: 'true',
+    SHOW_STACK_TRACE: 'true',
     GITHUB_REPOSITORY: 'MY-REPOSITORY-NAME',
     GITHUB_WORKFLOW: 'MY-WORKFLOW-ID',
     GITHUB_ACTION: 'MY-ACTION-NAME',
@@ -141,7 +141,7 @@ describe('Configure AWS Credentials', () => {
     });
 
     test('error is caught by core.setFailed and caught', async () => {
-        process.env.DO_NOT_SUPPRESS_STACK_TRACE = 'false';
+        process.env.SHOW_STACK_TRACE = 'false';
 
         mockStsCallerIdentity.mockImplementation(() => {
             throw new Error();


### PR DESCRIPTION
*Description of changes:*

As a security-conscious developer, long-lived credentials make me nervous, especially when I do not have a mechanism for an automated actor to change or delete them. Ideally, I would like to constantly refresh the GitHub Secrets that hold my AWS credentials with constantly rotating, short-lived, IAM Role credentials. Unfortunately, until GitHub adds an API for Secrets I cannot do that.

As a halfway measure, I would like to be able to set long-lived credentials in my GitHub Secrets that only have the permissions to assume short-lived credentials with wider permissions. The purpose of this PR is to enable this use-case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
