### PR TITLE
fix: sanitize AWS session tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,39 @@ We recommend following [Amazon IAM best practices](https://docs.aws.amazon.com/I
 * [Rotate the credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#rotate-credentials) used in GitHub Actions workflows regularly.
 * [Monitor the activity](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#keep-a-log) of the credentials used in GitHub Actions workflows.
 
+## Assuming a role
+If you would like to use some use the credentials you provide to this action to assume a role, you can do so by specifying the role ARN in `role-to-assume`.
+These crentials will then be output instead of the ones you have provided.  
+The default session duration is 6 hours, but if you would like to adjust this you can pass `role-duration-seconds`.
+
+Example:
+```yaml
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
+        role-to-assume: arn:aws:iam::123456789100:role/role-to-assume
+        role-duration-seconds: 1200
+```
+
+### Session tagging
+The session will be tagged with the following tags:  
+(`GITHUB_` environement variable definitions can be [found here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables))
+
+| Key | Value|
+| --- | --- |
+| GitHub | "Actions" |
+| Repository | GITHUB_REPOSITORY |
+| Workflow | GITHUB_WORKFLOW |
+| Action | GITHUB_ACTION |
+| Actor | GITHUB_ACTOR |
+| Branch | GITHUB_REF |
+| Commit | GITHUB_SHA |
+
+_Note: all tag values must conform to [the requirements](https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html). Particularly `GITHUB_ACTOR` or `GITHUB_WORKFLOW` will be truncated and if they contain invalid charcters, they will be replaced with an '*'._
+
 ## License Summary
 
 This code is made available under the MIT license.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ We recommend following [Amazon IAM best practices](https://docs.aws.amazon.com/I
 * [Monitor the activity](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#keep-a-log) of the credentials used in GitHub Actions workflows.
 
 ## Assuming a role
-If you would like to use some use the credentials you provide to this action to assume a role, you can do so by specifying the role ARN in `role-to-assume`.
-These crentials will then be output instead of the ones you have provided.  
-The default session duration is 6 hours, but if you would like to adjust this you can pass `role-duration-seconds`.
+If you would like to use the credentials you provide to this action to assume a role, you can do so by specifying the role ARN in `role-to-assume`.
+The role credentials will then be output instead of the ones you have provided.  
+The default session duration is 6 hours, but if you would like to adjust this you can pass a duration to `role-duration-seconds`.
 
 Example:
 ```yaml
@@ -44,7 +44,7 @@ Example:
 ```
 
 ### Session tagging
-The session will be tagged with the following tags:  
+The session will have the name "GitHubActions" and be tagged with the following tags:  
 (`GITHUB_` environement variable definitions can be [found here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables))
 
 | Key | Value|
@@ -57,7 +57,7 @@ The session will be tagged with the following tags:
 | Branch | GITHUB_REF |
 | Commit | GITHUB_SHA |
 
-_Note: all tag values must conform to [the requirements](https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html). Particularly `GITHUB_ACTOR` or `GITHUB_WORKFLOW` will be truncated and if they contain invalid charcters, they will be replaced with an '*'._
+_Note: all tag values must conform to [the requirements](https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html). Particularly, `GITHUB_WORKFLOW` will be truncated if it's too long. If `GITHUB_ACTOR` or `GITHUB_WORKFLOW` contain invalid charcters, the characters will be replaced with an '*'._
 
 ## License Summary
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example:
 
 ### Session tagging
 The session will have the name "GitHubActions" and be tagged with the following tags:  
-(`GITHUB_` environement variable definitions can be [found here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables))
+(`GITHUB_` environment variable definitions can be [found here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables))
 
 | Key | Value|
 | --- | --- |

--- a/index.js
+++ b/index.js
@@ -56,9 +56,7 @@ async function assumeRole(params) {
 function sanitizeGithubActor(actor) {
   // In some circumstances the actor may contain square brackets. For example, if they're a bot ('[bot]')
   // Square brackets are not allowed in AWS session tags
-  let sanitizedActor = actor.replace('[', '_')
-  sanitizedActor = sanitizedActor.replace(']', '_')
-  return sanitizedActor
+  return actor.replace(/\[|\]/g, '_')
 }
 
 function exportCredentials(params){

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function assumeRole(params) {
       {Key: 'Repository', Value: GITHUB_REPOSITORY},
       {Key: 'Workflow', Value: GITHUB_WORKFLOW},
       {Key: 'Action', Value: GITHUB_ACTION},
-      {Key: 'Actor', Value: GITHUB_ACTOR},
+      {Key: 'Actor', Value: sanitizeGithubActor(GITHUB_ACTOR)},
       {Key: 'Branch', Value: GITHUB_REF},
       {Key: 'Commit', Value: GITHUB_SHA},
     ]
@@ -51,6 +51,14 @@ async function assumeRole(params) {
       sessionToken: data.Credentials.SessionToken,
     };
   });
+}
+
+function sanitizeGithubActor(actor) {
+  // In some circumstances the actor may contain square brackets. For example, if they're a bot ('[bot]')
+  // Square brackets are not allowed in AWS session tags
+  let sanitizedActor = actor.replace('[', '_')
+  sanitizedActor = sanitizedActor.replace(']', '_')
+  return sanitizedActor
 }
 
 function exportCredentials(params){

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function assumeRole(params) {
     Tags: [
       {Key: 'GitHub', Value: 'Actions'},
       {Key: 'Repository', Value: GITHUB_REPOSITORY},
-      {Key: 'Workflow', Value: sanitiseGithubWorkflowName(GITHUB_WORKFLOW)},
+      {Key: 'Workflow', Value: sanitizeGithubWorkflowName(GITHUB_WORKFLOW)},
       {Key: 'Action', Value: GITHUB_ACTION},
       {Key: 'Actor', Value: sanitizeGithubActor(GITHUB_ACTOR)},
       {Key: 'Branch', Value: GITHUB_REF},
@@ -61,7 +61,7 @@ function sanitizeGithubActor(actor) {
   return actor.replace(/\[|\]/g, SANITIZATION_CHARACTER)
 }
 
-function sanitiseGithubWorkflowName(name) {
+function sanitizeGithubWorkflowName(name) {
   // Workflow names can be almost any valid UTF-8 string, but tags are more restrictive.
   // This replaces anything not conforming to the tag restrictions by inverting the regular expression.
   // See the AWS documentation for constraint specifics https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html.

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const util = require('util');
 const MAX_ACTION_RUNTIME = 6 * 3600;
 const USER_AGENT = 'configure-aws-credentials-for-github-actions';
 const MAX_TAG_VALUE_LENGTH = 256;
+const SANITIZATION_CHARACTER = '*'
 
 async function assumeRole(params) {
   // Assume a role to get short-lived credentials using longer-lived credentials.
@@ -57,14 +58,14 @@ async function assumeRole(params) {
 function sanitizeGithubActor(actor) {
   // In some circumstances the actor may contain square brackets. For example, if they're a bot ('[bot]')
   // Square brackets are not allowed in AWS session tags
-  return actor.replace(/\[|\]/g, '_')
+  return actor.replace(/\[|\]/g, SANITIZATION_CHARACTER)
 }
 
 function sanitiseGithubWorkflowName(name) {
   // Workflow names can be almost any valid UTF-8 string, but tags are more restrictive.
   // This replaces anything not conforming to the tag restrictions by inverting the regular expression.
   // See the AWS documentation for constraint specifics https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html.
-  const nameWithoutSpecialCharacters = name.replace(/[^\p{L}\p{Z}\p{N}_.:/=+-@]/gu, '_');
+  const nameWithoutSpecialCharacters = name.replace(/[^\p{L}\p{Z}\p{N}_.:/=+-@]/gu, SANITIZATION_CHARACTER);
   const nameTruncated = nameWithoutSpecialCharacters.slice(0, MAX_TAG_VALUE_LENGTH)
   return nameTruncated
 }

--- a/index.test.js
+++ b/index.test.js
@@ -245,7 +245,7 @@ describe('Configure AWS Credentials', () => {
         
         process.env = {...process.env, GITHUB_WORKFLOW: 'Workflow!"#$%&\'()*+, -./:;<=>?@[]^_`{|}~🙂💥🍌1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZai9D2AN2RlWCxtMqChNtxuxjqeqhoQZo0oaq39sjcRZgAAAAAAA'};
 
-        const sanitisedWorkflowName = 'Workflow**********+, -./:;<=>?@***_********1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZa'
+        const sanitizedWorkflowName = 'Workflow**********+, -./:;<=>?@***_********1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZa'
 
         await run();
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
@@ -255,7 +255,7 @@ describe('Configure AWS Credentials', () => {
             Tags: [
                 {Key: 'GitHub', Value: 'Actions'},
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
-                {Key: 'Workflow', Value: sanitisedWorkflowName},
+                {Key: 'Workflow', Value: sanitizedWorkflowName},
                 {Key: 'Action', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTION},
                 {Key: 'Actor', Value: GITHUB_ACTOR_SANITIZED},
                 {Key: 'Branch', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REF},

--- a/index.test.js
+++ b/index.test.js
@@ -19,10 +19,11 @@ const ENVIRONMENT_VARIABLE_OVERRIDES = {
     GITHUB_REPOSITORY: 'MY-REPOSITORY-NAME',
     GITHUB_WORKFLOW: 'MY-WORKFLOW-ID',
     GITHUB_ACTION: 'MY-ACTION-NAME',
-    GITHUB_ACTOR: 'MY-USERNAME',
+    GITHUB_ACTOR: 'MY-USERNAME[bot]',
     GITHUB_REF: 'MY-BRANCH',
     GITHUB_SHA: 'MY-COMMIT-ID',
 };
+const GITHUB_ACTOR_SANITIZED = 'MY-USERNAME_bot_'
 
 function mockGetInput(requestResponse) {
     return function (name, options) { // eslint-disable-line no-unused-vars
@@ -208,7 +209,7 @@ describe('Configure AWS Credentials', () => {
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
                 {Key: 'Workflow', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_WORKFLOW},
                 {Key: 'Action', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTION},
-                {Key: 'Actor', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTOR},
+                {Key: 'Actor', Value: GITHUB_ACTOR_SANITIZED},
                 {Key: 'Branch', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REF},
                 {Key: 'Commit', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_SHA},
             ]
@@ -230,7 +231,7 @@ describe('Configure AWS Credentials', () => {
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
                 {Key: 'Workflow', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_WORKFLOW},
                 {Key: 'Action', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTION},
-                {Key: 'Actor', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTOR},
+                {Key: 'Actor', Value: GITHUB_ACTOR_SANITIZED},
                 {Key: 'Branch', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REF},
                 {Key: 'Commit', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_SHA},
             ]

--- a/index.test.js
+++ b/index.test.js
@@ -23,7 +23,7 @@ const ENVIRONMENT_VARIABLE_OVERRIDES = {
     GITHUB_REF: 'MY-BRANCH',
     GITHUB_SHA: 'MY-COMMIT-ID',
 };
-const GITHUB_ACTOR_SANITIZED = 'MY-USERNAME_bot_'
+const GITHUB_ACTOR_SANITIZED = 'MY-USERNAME*bot*'
 
 function mockGetInput(requestResponse) {
     return function (name, options) { // eslint-disable-line no-unused-vars
@@ -245,7 +245,7 @@ describe('Configure AWS Credentials', () => {
         
         process.env = {...process.env, GITHUB_WORKFLOW: 'Workflow!"#$%&\'()*+, -./:;<=>?@[]^_`{|}~🙂💥🍌1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZai9D2AN2RlWCxtMqChNtxuxjqeqhoQZo0oaq39sjcRZgAAAAAAA'};
 
-        const sanitisedWorkflowName = 'Workflow__________+, -./:;<=>?@____________1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZa'
+        const sanitisedWorkflowName = 'Workflow**********+, -./:;<=>?@***_********1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZa'
 
         await run();
         expect(mockStsAssumeRole).toHaveBeenCalledWith({

--- a/index.test.js
+++ b/index.test.js
@@ -238,4 +238,30 @@ describe('Configure AWS Credentials', () => {
         })
     });
 
+    test('workflow name sanitized in role assumption tags', async () => {
+        core.getInput = jest
+            .fn()
+            .mockImplementation(mockGetInput(ASSUME_ROLE_INPUTS));
+        
+        process.env = {...process.env, GITHUB_WORKFLOW: 'Workflow!"#$%&\'()*+, -./:;<=>?@[]^_`{|}~🙂💥🍌1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZai9D2AN2RlWCxtMqChNtxuxjqeqhoQZo0oaq39sjcRZgAAAAAAA'};
+
+        const sanitisedWorkflowName = 'Workflow__________+, -./:;<=>?@____________1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZa'
+
+        await run();
+        expect(mockStsAssumeRole).toHaveBeenCalledWith({
+            RoleArn: ROLE_NAME,
+            RoleSessionName: 'GitHubActions',
+            DurationSeconds: 6 * 3600,
+            Tags: [
+                {Key: 'GitHub', Value: 'Actions'},
+                {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
+                {Key: 'Workflow', Value: sanitisedWorkflowName},
+                {Key: 'Action', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTION},
+                {Key: 'Actor', Value: GITHUB_ACTOR_SANITIZED},
+                {Key: 'Branch', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REF},
+                {Key: 'Commit', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_SHA},
+            ]
+        })
+    });
+
 });


### PR DESCRIPTION
Closes #18 

Ensure that alls tags applied to the AWS role session are valid.

For `GITHUB_ACTOR`, `[` and `]` must be removed.

For `GITHUB_WORKFLOW` I've inverted the [tag value requirement regex](https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html), `[\p{L}\p{Z}\p{N}_.:/=+\-@]+`, and replaced any characters that don't conform. I've also truncated the value as it has a maximum of 256 chars.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.