### PR TITLE
fix: change sanitization character from '*' to '_' for assume role tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const util = require('util');
 const MAX_ACTION_RUNTIME = 6 * 3600;
 const USER_AGENT = 'configure-aws-credentials-for-github-actions';
 const MAX_TAG_VALUE_LENGTH = 256;
-const SANITIZATION_CHARACTER = '*'
+const SANITIZATION_CHARACTER = '_'
 
 async function assumeRole(params) {
   // Assume a role to get short-lived credentials using longer-lived credentials.

--- a/index.test.js
+++ b/index.test.js
@@ -23,7 +23,7 @@ const ENVIRONMENT_VARIABLE_OVERRIDES = {
     GITHUB_REF: 'MY-BRANCH',
     GITHUB_SHA: 'MY-COMMIT-ID',
 };
-const GITHUB_ACTOR_SANITIZED = 'MY-USERNAME*bot*'
+const GITHUB_ACTOR_SANITIZED = 'MY-USERNAME_bot_'
 
 function mockGetInput(requestResponse) {
     return function (name, options) { // eslint-disable-line no-unused-vars
@@ -245,7 +245,7 @@ describe('Configure AWS Credentials', () => {
         
         process.env = {...process.env, GITHUB_WORKFLOW: 'Workflow!"#$%&\'()*+, -./:;<=>?@[]^_`{|}~🙂💥🍌1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZai9D2AN2RlWCxtMqChNtxuxjqeqhoQZo0oaq39sjcRZgAAAAAAA'};
 
-        const sanitizedWorkflowName = 'Workflow**********+, -./:;<=>?@***_********1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZa'
+        const sanitizedWorkflowName = 'Workflow__________+, -./:;<=>?@____________1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZa'
 
         await run();
         expect(mockStsAssumeRole).toHaveBeenCalledWith({


### PR DESCRIPTION
Tags must conform to the pattern `[\p{L}\p{Z}\p{N}_.:/=+\-@]*`, so replacing with `*` isn't sufficient for sanitization.

I think underscore should work fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
