### PR TITLE
feat: Have an ability to configure session name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ We recommend following [Amazon IAM best practices](https://docs.aws.amazon.com/I
 ## Assuming a role
 If you would like to use the credentials you provide to this action to assume a role, you can do so by specifying the role ARN in `role-to-assume`.
 The role credentials will then be output instead of the ones you have provided.
-The default session duration is 6 hours, but if you would like to adjust this you can pass a duration to `role-duration-seconds`.
+The default session duration is 6 hours, but if you would like to adjust this you can pass a duration to `role-duration-seconds`. 
+The default session name is **GitHubActions**, and you can modify it by specifying the desired name in `role-session-name`.
 
 Example:
 ```yaml
@@ -65,6 +66,7 @@ Example:
         aws-region: us-east-2
         role-to-assume: arn:aws:iam::123456789100:role/role-to-assume
         role-duration-seconds: 1200
+        role-session-name: MySessionName
 ```
 
 ### Session tagging

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ We recommend following [Amazon IAM best practices](https://docs.aws.amazon.com/I
 If you would like to use the credentials you provide to this action to assume a role, you can do so by specifying the role ARN in `role-to-assume`.
 The role credentials will then be output instead of the ones you have provided.
 The default session duration is 6 hours, but if you would like to adjust this you can pass a duration to `role-duration-seconds`. 
-The default session name is **GitHubActions**, and you can modify it by specifying the desired name in `role-session-name`.
+The default session name is GitHubActions, and you can modify it by specifying the desired name in `role-session-name`.
 
 Example:
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   role-duration-seconds:
     description: "Role duration in seconds (default: 6 hours)"
     required: false
+  role-session-name:
+    description: 'Role Session Name (default: GitHubActions)'
+    required: false
 outputs:
   aws-account-id:
     description: 'The AWS account ID for the provided credentials'

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: "Role duration in seconds (default: 6 hours)"
     required: false
   role-session-name:
-    description: 'Role Session Name (default: GitHubActions)'
+    description: 'Role session name (default: GitHubActions)'
     required: false
 outputs:
   aws-account-id:

--- a/index.test.js
+++ b/index.test.js
@@ -238,6 +238,28 @@ describe('Configure AWS Credentials', () => {
         })
     });
 
+    test('role assumption session name provided', async () => {
+        core.getInput = jest
+            .fn()
+            .mockImplementation(mockGetInput({...ASSUME_ROLE_INPUTS, 'role-session-name': 'MySessionName'}));
+
+        await run();
+        expect(mockStsAssumeRole).toHaveBeenCalledWith({
+            RoleArn: ROLE_NAME,
+            RoleSessionName: 'MySessionName',
+            DurationSeconds: 6 * 3600,
+            Tags: [
+                {Key: 'GitHub', Value: 'Actions'},
+                {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
+                {Key: 'Workflow', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_WORKFLOW},
+                {Key: 'Action', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTION},
+                {Key: 'Actor', Value: GITHUB_ACTOR_SANITIZED},
+                {Key: 'Branch', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REF},
+                {Key: 'Commit', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_SHA},
+            ]
+        })
+    });
+
     test('workflow name sanitized in role assumption tags', async () => {
         core.getInput = jest
             .fn()


### PR DESCRIPTION
Hi, 

I submit this PR for an ability to configure role session name after assuming a role with `configure-aws-credentials` Actions.

The story behind this PR is, recently, AWS has released a new feature for IAM - "CalledVia." It's a cool feature and no need to give extra write permissions to people to create stacks with CloudFormation. Now, we are changing our way of working by integrating GitHub Actions to deploy CloudFormation templates, but also want to know who update templates by using AWS CloudTrail. 

We figure out the CloudTrail will take session name as user name. Therefore we want to have a configurable session name to tag meaningful information on it instead of GitHubActions.