### PR TITLE
fix: validate region input string

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const USER_AGENT = 'configure-aws-credentials-for-github-actions';
 const MAX_TAG_VALUE_LENGTH = 256;
 const SANITIZATION_CHARACTER = '_';
 const ROLE_SESSION_NAME = 'GitHubActions';
+const REGION_REGEX = /^[a-z0-9-]+$/g;
 
 async function assumeRole(params) {
   // Assume a role to get short-lived credentials using longer-lived credentials.
@@ -150,6 +151,10 @@ async function run() {
     const roleExternalId = core.getInput('role-external-id', { required: false });
     const roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || MAX_ACTION_RUNTIME;
     const roleSessionName = core.getInput('role-session-name', { required: false }) || ROLE_SESSION_NAME;
+
+    if (!region.match(REGION_REGEX)) {
+      throw new Error(`Region is not valid: ${region}`);
+    }
 
     exportRegion(region);
 

--- a/index.test.js
+++ b/index.test.js
@@ -154,6 +154,19 @@ describe('Configure AWS Credentials', () => {
         expect(core.setSecret).toHaveBeenCalledWith(FAKE_ACCOUNT_ID);
     });
 
+    test('validates region name', async () => {
+        process.env.SHOW_STACK_TRACE = 'false';
+
+        const mockInputs = {...CREDS_INPUTS, 'aws-region': '$AWS_REGION'};
+        core.getInput = jest
+            .fn()
+            .mockImplementation(mockGetInput(mockInputs));
+
+        await run();
+
+        expect(core.setFailed).toHaveBeenCalledWith('Region is not valid: $AWS_REGION');
+    });
+
     test('can opt out of masking account ID', async () => {
         const mockInputs = {...CREDS_INPUTS, 'aws-region': 'us-east-1', 'mask-aws-account-id': 'false'};
         core.getInput = jest


### PR DESCRIPTION
Related to #43 

Use a fairly permissive regex to check if the given region could feasibly be a valid region string.  Whether it is actually a valid region will be checked when `https://sts.$region.amazonaws.com` is called to get the account ID.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
