### PR TITLE
fix: clear session token env var if present for non-session credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Add the following step to your workflow:
 ```
 
 For example, you can use this action with the AWS CLI available in [GitHub's hosted virtual environments](https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners).
+You can also run this action multiple times to use different AWS accounts, regions, or IAM roles in the same GitHub Actions workflow job.
 
 ```yaml
 jobs:
@@ -42,16 +43,27 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Configure AWS credentials
+    - name: Configure AWS credentials from Test account
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-2
+        aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
 
-    - name: Copy files to S3 with the AWS CLI
+    - name: Copy files to the test website with the AWS CLI
       run: |
-        aws s3 sync . s3://my-s3-website-bucket
+        aws s3 sync . s3://my-s3-test-website-bucket
+
+    - name: Configure AWS credentials from Production account
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+
+    - name: Copy files to the production website with the AWS CLI
+      run: |
+        aws s3 sync . s3://my-s3-prod-website-bucket
 ```
 
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.

--- a/index.js
+++ b/index.js
@@ -107,6 +107,9 @@ function exportCredentials(params){
   if (sessionToken) {
     core.exportVariable('AWS_SESSION_TOKEN', sessionToken);
     core.setSecret(sessionToken);
+  } else if (process.env.AWS_SESSION_TOKEN) {
+    // clear session token from previous credentials action
+    core.exportVariable('AWS_SESSION_TOKEN', '');
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -154,6 +154,28 @@ describe('Configure AWS Credentials', () => {
         expect(core.setSecret).toHaveBeenCalledWith(FAKE_ACCOUNT_ID);
     });
 
+    test('session token is cleared if necessary', async () => {
+        const mockInputs = {...CREDS_INPUTS, 'aws-region': 'eu-west-1'};
+        core.getInput = jest
+            .fn()
+            .mockImplementation(mockGetInput(mockInputs));
+        process.env.AWS_SESSION_TOKEN = 'helloworld';
+
+        await run();
+        expect(mockStsAssumeRole).toHaveBeenCalledTimes(0);
+        expect(core.exportVariable).toHaveBeenCalledTimes(5);
+        expect(core.setSecret).toHaveBeenCalledTimes(3);
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_ACCESS_KEY_ID', FAKE_ACCESS_KEY_ID);
+        expect(core.setSecret).toHaveBeenCalledWith(FAKE_ACCESS_KEY_ID);
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_SECRET_ACCESS_KEY', FAKE_SECRET_ACCESS_KEY);
+        expect(core.setSecret).toHaveBeenCalledWith(FAKE_SECRET_ACCESS_KEY);
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_SESSION_TOKEN', '');
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_DEFAULT_REGION', 'eu-west-1');
+        expect(core.exportVariable).toHaveBeenCalledWith('AWS_REGION', 'eu-west-1');
+        expect(core.setOutput).toHaveBeenCalledWith('aws-account-id', FAKE_ACCOUNT_ID);
+        expect(core.setSecret).toHaveBeenCalledWith(FAKE_ACCOUNT_ID);
+    });
+
     test('validates region name', async () => {
         process.env.SHOW_STACK_TRACE = 'false';
 


### PR DESCRIPTION
Related to #57, also document how to use different AWS accounts in the readme

This change is only necessary where the first action requires a session token, but the second action doesn't. For example:
```
    - name: Configure AWS credentials from Production account
      uses: aws-actions/configure-aws-credentials@v1
      with:
        aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
        aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
        aws-region: us-west-2

    - name: Configure AWS credentials from Production account
      uses: aws-actions/configure-aws-credentials@v1
      with:
        aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
        aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
        aws-region: us-west-2
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
