### PR TITLE
fix: Mask assume role response in debug output

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,19 +98,19 @@ function exportCredentials(params){
 
   // AWS_ACCESS_KEY_ID:
   // Specifies an AWS access key associated with an IAM user or role
-  core.exportVariable('AWS_ACCESS_KEY_ID', accessKeyId);
   core.setSecret(accessKeyId);
+  core.exportVariable('AWS_ACCESS_KEY_ID', accessKeyId);
 
   // AWS_SECRET_ACCESS_KEY:
   // Specifies the secret key associated with the access key. This is essentially the "password" for the access key.
-  core.exportVariable('AWS_SECRET_ACCESS_KEY', secretAccessKey);
   core.setSecret(secretAccessKey);
+  core.exportVariable('AWS_SECRET_ACCESS_KEY', secretAccessKey);
 
   // AWS_SESSION_TOKEN:
   // Specifies the session token value that is required if you are using temporary security credentials.
   if (sessionToken) {
-    core.exportVariable('AWS_SESSION_TOKEN', sessionToken);
     core.setSecret(sessionToken);
+    core.exportVariable('AWS_SESSION_TOKEN', sessionToken);
   } else if (process.env.AWS_SESSION_TOKEN) {
     // clear session token from previous credentials action
     core.exportVariable('AWS_SESSION_TOKEN', '');
@@ -129,10 +129,10 @@ async function exportAccountId(maskAccountId, region) {
   const sts = getStsClient(region);
   const identity = await sts.getCallerIdentity().promise();
   const accountId = identity.Account;
-  core.setOutput('aws-account-id', accountId);
   if (!maskAccountId || maskAccountId.toLowerCase() == 'true') {
     core.setSecret(accountId);
   }
+  core.setOutput('aws-account-id', accountId);
   return accountId;
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -594,4 +594,26 @@ describe('Configure AWS Credentials', () => {
         })
     });
 
+    test('masks variables before exporting', async () => {
+        let maskedValues = [];
+        const publicFields = ['AWS_REGION', 'AWS_DEFAULT_REGION'];
+        core.setSecret.mockReset();
+        core.setSecret.mockImplementation((secret) => {
+            maskedValues.push(secret);
+        });
+
+        core.exportVariable.mockReset();
+        core.exportVariable.mockImplementation((name, value) => {
+            if (!maskedValues.includes(value) && !publicFields.includes(name)) {
+                throw new Error(value + " for variable " + name + " is not masked yet!");
+            }
+        });
+
+        core.getInput = jest
+            .fn()
+            .mockImplementation(mockGetInput(ASSUME_ROLE_INPUTS));
+
+        await run();
+    });
+
 });


### PR DESCRIPTION
Ensuring assume-role response is masked from debug output. Previously, response elements could be logged in the case where debugging was turned on. 

--
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.