### PR TITLE
Change default role duration

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,8 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-// The max time that a GitHub action is allowed to run is 6 hours.
-// That seems like a reasonable default to use if no role duration is defined.
-const MAX_ACTION_RUNTIME = 6 * 3600;
+// Use the same default role duration as the AWS CLI.
+const DEFAULT_ROLE_DURATION = 3600;
 const DEFAULT_ROLE_DURATION_FOR_OIDC_ROLES = 3600;
 const USER_AGENT = 'configure-aws-credentials-for-github-actions';
 const MAX_TAG_VALUE_LENGTH = 256;
@@ -85,7 +84,7 @@ async function assumeRole(params) {
   }
 
   let assumeFunction = sts.assumeRole.bind(sts);
-  
+
   // These are customizations needed for the GH OIDC Provider
   if(isDefined(webIdentityToken)) {
     delete assumeRoleRequest.Tags;
@@ -110,8 +109,8 @@ async function assumeRole(params) {
     } catch(error) {
       throw new Error(`Web identity token file could not be read: ${error.message}`);
     }
-    
-  } 
+
+  }
 
   return assumeFunction(assumeRoleRequest)
     .promise()
@@ -269,7 +268,7 @@ async function run() {
     const maskAccountId = core.getInput('mask-aws-account-id', { required: false });
     const roleToAssume = core.getInput('role-to-assume', {required: false});
     const roleExternalId = core.getInput('role-external-id', { required: false });
-    let roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || MAX_ACTION_RUNTIME;
+    let roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || DEFAULT_ROLE_DURATION;
     const roleSessionName = core.getInput('role-session-name', { required: false }) || ROLE_SESSION_NAME;
     const roleSkipSessionTaggingInput = core.getInput('role-skip-session-tagging', { required: false })|| 'false';
     const roleSkipSessionTagging = roleSkipSessionTaggingInput.toLowerCase() === 'true';
@@ -303,7 +302,7 @@ async function run() {
 
       exportCredentials({accessKeyId, secretAccessKey, sessionToken});
     }
-    
+
     // Attempt to load credentials from the GitHub OIDC provider.
     // If a user provides an IAM Role Arn and DOESN'T provide an Access Key Id
     // The only way to assume the role is via GitHub's OIDC provider.

--- a/index.test.js
+++ b/index.test.js
@@ -470,7 +470,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
             RoleArn: ROLE_ARN,
             RoleSessionName: 'GitHubActions',
-            DurationSeconds: 6 * 3600,
+            DurationSeconds: 3600,
             Tags: [
                 {Key: 'GitHub', Value: 'Actions'},
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
@@ -514,7 +514,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
             RoleArn: ROLE_ARN,
             RoleSessionName: 'MySessionName',
-            DurationSeconds: 6 * 3600,
+            DurationSeconds: 3600,
             Tags: [
                 {Key: 'GitHub', Value: 'Actions'},
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
@@ -536,7 +536,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
             RoleArn: 'arn:aws:iam::123456789012:role/MY-ROLE',
             RoleSessionName: 'GitHubActions',
-            DurationSeconds: 6 * 3600,
+            DurationSeconds: 3600,
             Tags: [
                 {Key: 'GitHub', Value: 'Actions'},
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
@@ -558,7 +558,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRoleWithWebIdentity).toHaveBeenCalledWith({
             RoleArn: 'arn:aws:iam::111111111111:role/MY-ROLE',
             RoleSessionName: 'GitHubActions',
-            DurationSeconds: 6 * 3600,
+            DurationSeconds: 3600,
             WebIdentityToken: 'testpayload'
         })
     });
@@ -572,7 +572,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRoleWithWebIdentity).toHaveBeenCalledWith({
             RoleArn: 'arn:aws:iam::111111111111:role/MY-ROLE',
             RoleSessionName: 'GitHubActions',
-            DurationSeconds: 6 * 3600,
+            DurationSeconds: 3600,
             WebIdentityToken: 'testpayload'
         })
     });
@@ -643,7 +643,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
             RoleArn: ROLE_ARN,
             RoleSessionName: 'GitHubActions',
-            DurationSeconds: 6 * 3600,
+            DurationSeconds: 3600,
             Tags: [
                 {Key: 'GitHub', Value: 'Actions'},
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
@@ -670,7 +670,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
             RoleArn: ROLE_ARN,
             RoleSessionName: 'GitHubActions',
-            DurationSeconds: 6 * 3600,
+            DurationSeconds: 3600,
             Tags: [
                 {Key: 'GitHub', Value: 'Actions'},
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
@@ -692,7 +692,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
             RoleArn: ROLE_ARN,
             RoleSessionName: 'GitHubActions',
-            DurationSeconds: 21600,
+            DurationSeconds: 3600,
             Tags: undefined
         })
     });
@@ -706,7 +706,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
             RoleArn: ROLE_ARN,
             RoleSessionName: 'GitHubActions',
-            DurationSeconds: 21600,
+            DurationSeconds: 3600,
             Tags: [
                 {Key: 'GitHub', Value: 'Actions'},
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
@@ -728,7 +728,7 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
             RoleArn: ROLE_ARN,
             RoleSessionName: 'GitHubActions',
-            DurationSeconds: 21600,
+            DurationSeconds: 3600,
             Tags: [
                 {Key: 'GitHub', Value: 'Actions'},
                 {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},


### PR DESCRIPTION
*Issue #, if available:* #103 

*Description of changes:*

use 1h instead of 6h to match AWS CLI default (as well as default `max_session_duration` for terraform `aws_iam_role` resource)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
