### PR TITLE
Readme: clarify that aws-session-token supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Add the following step to your workflow:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        # aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }} # if you have/need it
         aws-region: us-east-2
 ```
 


### PR DESCRIPTION
Update README.

I nearly gave up, believing it is not supported, until I read the action.yml. I think it is worth making this clear already in the README.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
