### PR TITLE
fix: skips session tagging

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,12 @@ async function assumeRole(params) {
 
   const roleSessionTags = roleSkipSessionTagging ? undefined : tagArray;
 
+  if(roleSessionTags == undefined){
+    core.debug("Role session tagging has been skipped.")
+  } else {
+    core.debug(roleSessionTags.length + " role session tags are being used.")
+  }
+
   const assumeRoleRequest = {
     RoleArn: roleArn,
     RoleSessionName: roleSessionName,
@@ -203,8 +209,9 @@ async function run() {
     const roleExternalId = core.getInput('role-external-id', { required: false });
     const roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || MAX_ACTION_RUNTIME;
     const roleSessionName = core.getInput('role-session-name', { required: false }) || ROLE_SESSION_NAME;
-    const roleSkipSessionTagging = core.getInput('role-skip-session-tagging', { required: false });
-  
+    const roleSkipSessionTaggingInput = core.getInput('role-skip-session-tagging', { required: false })|| 'false';
+    const roleSkipSessionTagging = roleSkipSessionTaggingInput.toLowerCase() === 'true';
+
     if (!region.match(REGION_REGEX)) {
       throw new Error(`Region is not valid: ${region}`);
     }

--- a/index.test.js
+++ b/index.test.js
@@ -559,7 +559,7 @@ describe('Configure AWS Credentials', () => {
     test('skip tagging provided as true', async () => {
         core.getInput = jest
             .fn()
-            .mockImplementation(mockGetInput({...ASSUME_ROLE_INPUTS, 'role-skip-session-tagging': true}));
+            .mockImplementation(mockGetInput({...ASSUME_ROLE_INPUTS, 'role-skip-session-tagging': 'true'}));
 
         await run();
         expect(mockStsAssumeRole).toHaveBeenCalledWith({
@@ -573,7 +573,7 @@ describe('Configure AWS Credentials', () => {
     test('skip tagging provided as false', async () => {
         core.getInput = jest
             .fn()
-            .mockImplementation(mockGetInput({...ASSUME_ROLE_INPUTS, 'role-skip-session-tagging': false}));
+            .mockImplementation(mockGetInput({...ASSUME_ROLE_INPUTS, 'role-skip-session-tagging': 'false'}));
 
         await run();
         expect(mockStsAssumeRole).toHaveBeenCalledWith({


### PR DESCRIPTION
This PR fix the issue #199

Description of changes:
This issue was occurring due to incorrect data type of the `role-skip-session-tagging` parameter.
In order to fix this issue need to type caste the value of the `role-skip-session-tagging `parameter from string to boolean.

when `role-skip-session-tagging` is false

<img width="381" alt="Screen Shot 2021-05-11 at 2 53 31 PM" src="https://user-images.githubusercontent.com/18301288/117869441-cd8f5e00-b268-11eb-9ab2-ff2ffc3b4c47.png">

when `role-skip-session-tagging` is true

<img width="388" alt="Screen Shot 2021-05-11 at 2 53 11 PM" src="https://user-images.githubusercontent.com/18301288/117869443-cd8f5e00-b268-11eb-8fe9-ea81470c186e.png">
