### PR TITLE
Add the ability to use a web identity token file

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ with:
 ```
 In this case, your runner's credentials must have permissions to assume the role.
 
+You can also assume a role using a web identity token file if using [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html).  Pods running in EKS worker nodes that do not run as root can use this file to assume a role with a web identity.
+
+You can configure your workflow as follows in order to use this file:
+```yaml
+uses: aws-actions/configure-aws-credentials@v1
+with:
+  aws-region: us-east-2
+  role-to-assume: my-github-actions-role
+  web-identity-token-file: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+```
+
 ### Use with the AWS CLI
 
 This workflow does _not_ install the [AWS CLI](https://aws.amazon.com/cli/) into your environment. Self-hosted runners that intend to run this action prior to executing `aws` commands need to have the AWS CLI [installed](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) if it's not already present. 

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
       environment with the assumed role credentials rather than with the provided
       credentials
     required: false
+  web-identity-token-file:
+      description: >-
+        Read the web identity token file from the provided file system path in order to 
+        assume an IAM role using a web identity on an EKS worker node
   role-duration-seconds:
     description: "Role duration in seconds (default: 6 hours)"
     required: false

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const core = require('@actions/core');
 const aws = require('aws-sdk');
 const assert = require('assert');
+const fs = require('fs').promises;
 
 // The max time that a GitHub action is allowed to run is 6 hours.
 // That seems like a reasonable default to use if no role duration is defined.
@@ -22,7 +23,8 @@ async function assumeRole(params) {
     roleDurationSeconds,
     roleSessionName,
     region,
-    roleSkipSessionTagging
+    roleSkipSessionTagging,
+    webIdentityTokenFile
   } = params;
   assert(
       [sourceAccountId, roleToAssume, roleDurationSeconds, roleSessionName, region].every(isDefined),
@@ -74,15 +76,22 @@ async function assumeRole(params) {
     assumeRoleRequest.ExternalId = roleExternalId;
   }
 
-  return sts.assumeRole(assumeRoleRequest)
-  .promise()
-  .then(function (data) {
-    return {
-      accessKeyId: data.Credentials.AccessKeyId,
-      secretAccessKey: data.Credentials.SecretAccessKey,
-      sessionToken: data.Credentials.SessionToken,
-    };
-  });
+  let assumeFunction = sts.assumeRole;
+
+  if(isDefined(webIdentityTokenFile)) {
+    assumeRoleRequest.WebIdentityToken = await fs.readFile(webIdentityTokenFile, 'utf8');
+    assumeFunction = sts.assumeRoleWithWebIdentity;
+  } 
+
+  return assumeFunction(assumeRoleRequest)
+    .promise()
+    .then(function (data) {
+      return {
+        accessKeyId: data.Credentials.AccessKeyId,
+        secretAccessKey: data.Credentials.SecretAccessKey,
+        sessionToken: data.Credentials.SessionToken,
+      };
+    });
 }
 
 function sanitizeGithubActor(actor) {
@@ -211,6 +220,7 @@ async function run() {
     const roleSessionName = core.getInput('role-session-name', { required: false }) || ROLE_SESSION_NAME;
     const roleSkipSessionTaggingInput = core.getInput('role-skip-session-tagging', { required: false })|| 'false';
     const roleSkipSessionTagging = roleSkipSessionTaggingInput.toLowerCase() === 'true';
+    const webIdentityTokenFile = core.getInput('web-identity-token-file', { required: false })
 
     if (!region.match(REGION_REGEX)) {
       throw new Error(`Region is not valid: ${region}`);
@@ -249,7 +259,8 @@ async function run() {
         roleExternalId,
         roleDurationSeconds,
         roleSessionName,
-        roleSkipSessionTagging
+        roleSkipSessionTagging,
+        webIdentityTokenFile
       });
       exportCredentials(roleCredentials);
       await validateCredentials(roleCredentials.accessKeyId);


### PR DESCRIPTION
*Issue #, if available:* : 

https://github.com/aws-actions/configure-aws-credentials/issues/124

*Description of changes:*

I would like to be able to use a github action to consume a web identity token file on an EKS worker node.  I have a self-hosted runner which does not run as `root` and thus it does not automatically get IRSA credentials, so my current workaround is to use a bash script which handles the assume role portions, but it doesn't neatly export the credentials the way this workflow does.  This pull request would allow users of this workflow to consume the web identity token file when assuming a role in a much cleaner fashion.
