### PR TITLE
feat: Add the ability to use a web identity token file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ Configure AWS credential and region environment variables for use in other GitHu
 
 <!-- toc -->
 
+- ["Configure AWS Credentials" Action For GitHub Actions](#configure-aws-credentials-action-for-github-actions)
 - [Usage](#usage)
 - [Credentials](#credentials)
 - [Assuming a Role](#assuming-a-role)
-    + [Permissions for assuming a role](#permissions-for-assuming-a-role)
-    + [Session tagging](#session-tagging)
+  - [Permissions for assuming a role](#permissions-for-assuming-a-role)
+  - [Session tagging](#session-tagging)
 - [Self-Hosted Runners](#self-hosted-runners)
+  - [Use with the AWS CLI](#use-with-the-aws-cli)
 - [License Summary](#license-summary)
 - [Security Disclosures](#security-disclosures)
 
@@ -189,7 +191,7 @@ with:
 ```
 In this case, your runner's credentials must have permissions to assume the role.
 
-You can also assume a role using a web identity token file if using [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html).  Pods running in EKS worker nodes that do not run as root can use this file to assume a role with a web identity.
+You can also assume a role using a web identity token file, such as if using [Amazon EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html).  Pods running in EKS worker nodes that do not run as root can use this file to assume a role with a web identity.
 
 You can configure your workflow as follows in order to use this file:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ with:
 ```
 In this case, your runner's credentials must have permissions to assume the role.
 
+You can also assume a role using a web identity token file if using [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html).  Pods running in EKS worker nodes that do not run as root can use this file to assume a role with a web identity.
+
+You can configure your workflow as follows in order to use this file:
+```yaml
+uses: aws-actions/configure-aws-credentials@v1
+with:
+  aws-region: us-east-2
+  role-to-assume: my-github-actions-role
+  web-identity-token-file: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+```
+
 ### Use with the AWS CLI
 
 This workflow does _not_ install the [AWS CLI](https://aws.amazon.com/cli/) into your environment. Self-hosted runners that intend to run this action prior to executing `aws` commands need to have the AWS CLI [installed](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) if it's not already present. 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@ Configure AWS credential and region environment variables for use in other GitHu
 
 <!-- toc -->
 
-- ["Configure AWS Credentials" Action For GitHub Actions](#configure-aws-credentials-action-for-github-actions)
 - [Usage](#usage)
 - [Credentials](#credentials)
 - [Assuming a Role](#assuming-a-role)
-  - [Permissions for assuming a role](#permissions-for-assuming-a-role)
-  - [Session tagging](#session-tagging)
+    + [Permissions for assuming a role](#permissions-for-assuming-a-role)
+    + [Session tagging](#session-tagging)
 - [Self-Hosted Runners](#self-hosted-runners)
-  - [Use with the AWS CLI](#use-with-the-aws-cli)
 - [License Summary](#license-summary)
 - [Security Disclosures](#security-disclosures)
 

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
       environment with the assumed role credentials rather than with the provided
       credentials
     required: false
+  web-identity-token-file:
+      description: >-
+        Read the web identity token file from the provided file system path in order to 
+        assume an IAM role using a web identity on an EKS worker node
   role-duration-seconds:
     description: "Role duration in seconds (default: 6 hours)"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ inputs:
     required: false
   web-identity-token-file:
     description: >-
-      Read the web identity token file from the provided file system path in order to 
-      assume an IAM role using a web identity on an EKS worker node
+      Use the web identity token file from the provided file system path in order to
+      assume an IAM role using a web identity. E.g., from within an Amazon EKS worker node
     required: false
   role-duration-seconds:
     description: "Role duration in seconds (default: 6 hours)"

--- a/action.yml
+++ b/action.yml
@@ -35,10 +35,10 @@ inputs:
       credentials
     required: false
   web-identity-token-file:
-      description: >-
-        Read the web identity token file from the provided file system path in order to 
-        assume an IAM role using a web identity on an EKS worker node
-      required: false
+    description: >-
+      Read the web identity token file from the provided file system path in order to 
+      assume an IAM role using a web identity on an EKS worker node
+    required: false
   role-duration-seconds:
     description: "Role duration in seconds (default: 6 hours)"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ inputs:
       description: >-
         Read the web identity token file from the provided file system path in order to 
         assume an IAM role using a web identity on an EKS worker node
+      required: false
   role-duration-seconds:
     description: "Role duration in seconds (default: 6 hours)"
     required: false

--- a/index.js
+++ b/index.js
@@ -45,6 +45,13 @@ async function assumeRole(params) {
     // Supports only 'aws' partition. Customers in other partitions ('aws-cn') will need to provide full ARN
     roleArn = `arn:aws:iam::${sourceAccountId}:role/${roleArn}`;
   }
+
+  const assumeRoleRequest = {
+    RoleArn: roleArn,
+    RoleSessionName: roleSessionName,
+    DurationSeconds: roleDurationSeconds
+  };
+
   const tagArray = [
     {Key: 'GitHub', Value: 'Actions'},
     {Key: 'Repository', Value: GITHUB_REPOSITORY},
@@ -58,20 +65,14 @@ async function assumeRole(params) {
     tagArray.push({Key: 'Branch', Value: process.env.GITHUB_REF});
   }
 
-  const roleSessionTags = roleSkipSessionTagging ? undefined : tagArray;
+  const roleSessionTags = roleSkipSessionTagging || isDefined(webIdentityTokenFile) ? undefined : tagArray;
 
   if(roleSessionTags == undefined){
     core.debug("Role session tagging has been skipped.")
   } else {
     core.debug(roleSessionTags.length + " role session tags are being used.")
+    assumeRoleRequest.Tags = roleSessionTags;
   }
-
-  const assumeRoleRequest = {
-    RoleArn: roleArn,
-    RoleSessionName: roleSessionName,
-    DurationSeconds: roleDurationSeconds,
-    Tags: roleSessionTags
-  };
 
   if (roleExternalId) {
     assumeRoleRequest.ExternalId = roleExternalId;

--- a/index.js
+++ b/index.js
@@ -61,18 +61,18 @@ async function assumeRole(params) {
 
   const roleSessionTags = roleSkipSessionTagging ? undefined : tagArray;
 
+  if(roleSessionTags == undefined){
+    core.debug("Role session tagging has been skipped.")
+  } else {
+    core.debug(roleSessionTags.length + " role session tags are being used.")
+  }
+
   const assumeRoleRequest = {
     RoleArn: roleArn,
     RoleSessionName: roleSessionName,
     DurationSeconds: roleDurationSeconds,
     Tags: roleSessionTags
   };
-
-  if(roleSessionTags == undefined){
-    core.debug("Role session tagging has been skipped.")
-  } else {
-    core.debug(roleSessionTags.length + " role session tags are being used.")
-  }
 
   if (roleExternalId) {
     assumeRoleRequest.ExternalId = roleExternalId;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const core = require('@actions/core');
 const aws = require('aws-sdk');
 const assert = require('assert');
-const fs = require('fs').promises;
+const fs = require('fs');
 const path = require('path');
 
 // The max time that a GitHub action is allowed to run is 6 hours.
@@ -77,19 +77,19 @@ async function assumeRole(params) {
     assumeRoleRequest.ExternalId = roleExternalId;
   }
 
-  let assumeFunction = sts.assumeRole;
+  let assumeFunction = sts.assumeRole.bind(sts);
 
   if(isDefined(webIdentityTokenFile)) {
     const webIdentityTokenFilePath = path.isAbsolute(webIdentityTokenFile) ?
       webIdentityTokenFile :
       path.join(process.env.GITHUB_WORKSPACE, webIdentityTokenFile);
 
-    if (!await fs.exists(webIdentityTokenFilePath)) {
+    if (!fs.existsSync(webIdentityTokenFilePath)) {
       throw new Error(`Web identity token file does not exist: ${webIdentityTokenFilePath}`);
     }
 
-    assumeRoleRequest.WebIdentityToken = await fs.readFile(webIdentityTokenFilePath, 'utf8');
-    assumeFunction = sts.assumeRoleWithWebIdentity;
+    assumeRoleRequest.WebIdentityToken = await fs.promises.readFile(webIdentityTokenFilePath, 'utf8');
+    assumeFunction = sts.assumeRoleWithWebIdentity.bind(sts);
   } 
 
   return assumeFunction(assumeRoleRequest)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const core = require('@actions/core');
 const aws = require('aws-sdk');
 const assert = require('assert');
+const fs = require('fs').promises;
 
 // The max time that a GitHub action is allowed to run is 6 hours.
 // That seems like a reasonable default to use if no role duration is defined.
@@ -22,7 +23,8 @@ async function assumeRole(params) {
     roleDurationSeconds,
     roleSessionName,
     region,
-    roleSkipSessionTagging
+    roleSkipSessionTagging,
+    webIdentityTokenFile
   } = params;
   assert(
       [sourceAccountId, roleToAssume, roleDurationSeconds, roleSessionName, region].every(isDefined),
@@ -74,15 +76,22 @@ async function assumeRole(params) {
     assumeRoleRequest.ExternalId = roleExternalId;
   }
 
-  return sts.assumeRole(assumeRoleRequest)
-  .promise()
-  .then(function (data) {
-    return {
-      accessKeyId: data.Credentials.AccessKeyId,
-      secretAccessKey: data.Credentials.SecretAccessKey,
-      sessionToken: data.Credentials.SessionToken,
-    };
-  });
+  let assumeFunction = sts.assumeRole;
+
+  if(isDefined(webIdentityTokenFile)) {
+    assumeRoleRequest.WebIdentityToken = await fs.readFile(webIdentityTokenFile, 'utf8');
+    assumeFunction = sts.assumeRoleWithWebIdentity;
+  } 
+
+  return assumeFunction(assumeRoleRequest)
+    .promise()
+    .then(function (data) {
+      return {
+        accessKeyId: data.Credentials.AccessKeyId,
+        secretAccessKey: data.Credentials.SecretAccessKey,
+        sessionToken: data.Credentials.SessionToken,
+      };
+    });
 }
 
 function sanitizeGithubActor(actor) {
@@ -211,6 +220,7 @@ async function run() {
     const roleSessionName = core.getInput('role-session-name', { required: false }) || ROLE_SESSION_NAME;
     const roleSkipSessionTaggingInput = core.getInput('role-skip-session-tagging', { required: false })|| 'false';
     const roleSkipSessionTagging = roleSkipSessionTaggingInput.toLowerCase() === 'true';
+    const webIdentityTokenFile = core.getInput('web-identity-token-file', { required: false })
 
     if (!region.match(REGION_REGEX)) {
       throw new Error(`Region is not valid: ${region}`);
@@ -249,7 +259,8 @@ async function run() {
         roleExternalId,
         roleDurationSeconds,
         roleSessionName,
-        roleSkipSessionTagging
+        roleSkipSessionTagging,
+        webIdentityTokenFile
       });
       exportCredentials(roleCredentials);
       await validateCredentials(roleCredentials.accessKeyId);

--- a/index.test.js
+++ b/index.test.js
@@ -543,16 +543,7 @@ describe('Configure AWS Credentials', () => {
             RoleArn: 'arn:aws:iam::111111111111:role/MY-ROLE',
             RoleSessionName: 'GitHubActions',
             DurationSeconds: 6 * 3600,
-            WebIdentityToken: 'testpayload',
-            Tags: [
-                {Key: 'GitHub', Value: 'Actions'},
-                {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
-                {Key: 'Workflow', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_WORKFLOW},
-                {Key: 'Action', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTION},
-                {Key: 'Actor', Value: GITHUB_ACTOR_SANITIZED},
-                {Key: 'Commit', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_SHA},
-                {Key: 'Branch', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REF},
-            ]
+            WebIdentityToken: 'testpayload'
         })
     });
 
@@ -566,16 +557,7 @@ describe('Configure AWS Credentials', () => {
             RoleArn: 'arn:aws:iam::111111111111:role/MY-ROLE',
             RoleSessionName: 'GitHubActions',
             DurationSeconds: 6 * 3600,
-            WebIdentityToken: 'testpayload',
-            Tags: [
-                {Key: 'GitHub', Value: 'Actions'},
-                {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
-                {Key: 'Workflow', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_WORKFLOW},
-                {Key: 'Action', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTION},
-                {Key: 'Actor', Value: GITHUB_ACTOR_SANITIZED},
-                {Key: 'Commit', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_SHA},
-                {Key: 'Branch', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REF},
-            ]
+            WebIdentityToken: 'testpayload'
         })
     });
 

--- a/index.test.js
+++ b/index.test.js
@@ -66,8 +66,8 @@ jest.mock('fs', () => {
     return {
         promises: {
             readFile: jest.fn(() => Promise.resolve('testpayload')),
-            exists: jest.fn(() => Promise.resolve(true))
-        }
+        },
+        existsSync: jest.fn(() => true)
     };
 });
 


### PR DESCRIPTION
*Issue #, if available:* : 

https://github.com/aws-actions/configure-aws-credentials/issues/124

*Description of changes:*

I would like to be able to use a github action to consume a web identity token file on an EKS worker node.  I have a self-hosted runner which does not run as `root` and thus it does not automatically get IRSA credentials, so my current workaround is to use a bash script which handles the assume role portions, but it doesn't neatly export the credentials the way this workflow does.  This pull request would allow users of this workflow to consume the web identity token file when assuming a role in a much cleaner fashion.
