### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ jobs:
         aws s3 sync . s3://my-s3-prod-website-bucket
 ```
 
+**NOTE:** The workflow configuration above will upload the `.git` directory to the S3 Bucket. To exclude the `.git` directory, use:
+
+`aws s3 sync . s3://my-s3-prod-website-bucket --exclude ".git/*`
+
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.
 
 ## Credentials


### PR DESCRIPTION
Using the command: `aws s3 sync . s3://my-s3-prod-website-bucket` will upload the `.git` directory to the S3 Bucket, which is often not desired. Added a note to point this out.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
