### PR TITLE
fix: sanitise GITHUB_REF to be a valid tag value

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The session will have the name "GitHubActions" and be tagged with the following 
 | Branch | GITHUB_REF |
 | Commit | GITHUB_SHA |
 
-_Note: all tag values must conform to [the requirements](https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html). Particularly, `GITHUB_WORKFLOW` will be truncated if it's too long. If `GITHUB_ACTOR` or `GITHUB_WORKFLOW` contain invalid characters, the characters will be replaced with an '*'._
+_Note: all tag values must conform to [the requirements](https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html). Particularly, `GITHUB_WORKFLOW` & `GITHUB_BRANCH` will be truncated if they are too long. If `GITHUB_ACTOR`, `GITHUB_BRANCH`, or `GITHUB_WORKFLOW` contain invalid characters, those characters will be replaced with '_'._
 
 The action will use session tagging by default during role assumption. 
 Note that for WebIdentity role assumption, the session tags have to be included in the encoded WebIdentity token.

--- a/index.test.js
+++ b/index.test.js
@@ -661,6 +661,33 @@ describe('Configure AWS Credentials', () => {
         })
     });
 
+    test('ref name sanitized in role assumption tags', async () => {
+        core.getInput = jest
+            .fn()
+            .mockImplementation(mockGetInput(ASSUME_ROLE_INPUTS));
+
+        process.env = {...process.env, GITHUB_REF: 'refs/heads/!"#$%&\'()*+, -./:;<=>?@[]^_`{|}~🙂💥🍌1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLckZai9D2AN2RlWCxtMqChNtxuxjqeqhoQZo0oaq39sjcRZgAAAAAAA'};
+
+        const sanitizedRefName = 'refs/heads/__________+_ -./:;<=>?@____________1yFvMOeD3ZHYsHrGjCceOboMYzBPo0CRNFdcsVRG6UgR3A912a8KfcBtEVvkAS7kRBq80umGff8mux5IN1y55HQWPNBNyaruuVr4islFXte4FDQZexGJRUSMyHQpxJ8OmZnET84oDmbvmIjgxI6IBrdihX9PHMapT4gQvRYnLqNiKb18rEMWDNoZRy51UPX5sWK2GKPipgKSO9kqLc';
+
+        await run();
+        expect(mockStsAssumeRole).toHaveBeenCalledWith({
+            RoleArn: ROLE_ARN,
+            RoleSessionName: 'GitHubActions',
+            DurationSeconds: 6 * 3600,
+            Tags: [
+                {Key: 'GitHub', Value: 'Actions'},
+                {Key: 'Repository', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_REPOSITORY},
+                {Key: 'Workflow', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_WORKFLOW},
+                {Key: 'Action', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_ACTION},
+                {Key: 'Actor', Value: GITHUB_ACTOR_SANITIZED},
+                {Key: 'Commit', Value: ENVIRONMENT_VARIABLE_OVERRIDES.GITHUB_SHA},
+                {Key: 'Branch', Value: sanitizedRefName},
+            ]
+        })
+    });
+
+
     test('skip tagging provided as true', async () => {
         core.getInput = jest
             .fn()


### PR DESCRIPTION
Fixes #247

*Description of changes:*
Applies the same sanitization to Branch as is applied to Workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
