### PR TITLE
feat: added OIDC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -481,29 +481,29 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.2.0.tgz",
-      "integrity": "sha512-35z+RqsK2CCgNxn+lWyK8X4KkaDtfL4BggT7oeZ0JffIiAiEYFYPo5B67V50ZubqDS1ehBrdCR2jduFnIrZOYw==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.2.2.tgz",
+      "integrity": "sha512-m7tbzPWyvSFfoanTknJoDnaeruDARsUe555tkVjG/qeaRDKwyPqqbgs4yFx583gmoETiAts1deeYozR5sVRhNA==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.2.0",
+        "jest-message-util": "^27.2.2",
         "jest-util": "^27.2.0",
         "slash": "^3.0.0"
       }
     },
     "@jest/core": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.1.tgz",
-      "integrity": "sha512-XcGt9UgPyzylThvezwUIMCNVp8xxN78Ic3WwhJZehZt4n2hPHR6Bd85A1nKFZBeqW58Vd+Cx/LaN6YL4n58KlA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.2.tgz",
+      "integrity": "sha512-4b9km/h9pAGdCkwWYtbfoeiOtajOlGmr5rL1Eq6JCAVbOevOqxWHxJ6daWxRJW9eF6keXJoJ1H+uVAVcdZu8Bg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.2.0",
-        "@jest/reporters": "^27.2.1",
-        "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.1",
+        "@jest/console": "^27.2.2",
+        "@jest/reporters": "^27.2.2",
+        "@jest/test-result": "^27.2.2",
+        "@jest/transform": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -512,18 +512,18 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-changed-files": "^27.1.1",
-        "jest-config": "^27.2.1",
-        "jest-haste-map": "^27.2.0",
-        "jest-message-util": "^27.2.0",
+        "jest-config": "^27.2.2",
+        "jest-haste-map": "^27.2.2",
+        "jest-message-util": "^27.2.2",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.2.0",
-        "jest-resolve-dependencies": "^27.2.1",
-        "jest-runner": "^27.2.1",
-        "jest-runtime": "^27.2.1",
-        "jest-snapshot": "^27.2.1",
+        "jest-resolve": "^27.2.2",
+        "jest-resolve-dependencies": "^27.2.2",
+        "jest-runner": "^27.2.2",
+        "jest-runtime": "^27.2.2",
+        "jest-snapshot": "^27.2.2",
         "jest-util": "^27.2.0",
-        "jest-validate": "^27.2.0",
-        "jest-watcher": "^27.2.0",
+        "jest-validate": "^27.2.2",
+        "jest-watcher": "^27.2.2",
         "micromatch": "^4.0.4",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -532,52 +532,52 @@
       }
     },
     "@jest/environment": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.2.0.tgz",
-      "integrity": "sha512-iPWmQI0wRIYSZX3wKu4FXHK4eIqkfq6n1DCDJS+v3uby7SOXrHvX4eiTBuEdSvtDRMTIH2kjrSkjHf/F9JIYyQ==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.2.2.tgz",
+      "integrity": "sha512-gO9gVnZfn5ldeOJ5q+35Kru9QWGHEqZCB7W/M+8mD6uCwOGC9HR6mzpLSNRuDsxY/KhaGBYHpgFqtpe4Rl1gDQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.2.0",
+        "@jest/fake-timers": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "jest-mock": "^27.1.1"
       }
     },
     "@jest/fake-timers": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.2.0.tgz",
-      "integrity": "sha512-gSu3YHvQOoVaTWYGgHFB7IYFtcF2HBzX4l7s47VcjvkUgL4/FBnE20x7TNLa3W6ABERtGd5gStSwsA8bcn+c4w==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.2.2.tgz",
+      "integrity": "sha512-gDIIqs0yxyjyxEI9HlJ8SEJ4uCc8qr8BupG1Hcx7tvyk/SLocyXE63rFxL+HQ0ZLMvSyEcJUmYnvvHH1osWiGA==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
         "@sinonjs/fake-timers": "^7.0.2",
         "@types/node": "*",
-        "jest-message-util": "^27.2.0",
+        "jest-message-util": "^27.2.2",
         "jest-mock": "^27.1.1",
         "jest-util": "^27.2.0"
       }
     },
     "@jest/globals": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.1.tgz",
-      "integrity": "sha512-4P46Zr4cckSitsWtOMRvgMMn7mOKbBsQdYxHeGSIG3kpI4gNR2vk51balPulZHnBQCQb/XBptprtoSv1REfaew==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.2.tgz",
+      "integrity": "sha512-fWa/Luwod1hyehnuep+zCnOTqTVvyc4HLUU/1VpFNOEu0tCWNSODyvKSSOjtb1bGOpCNjgaDcyjzo5f7rl6a7g==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.2.0",
+        "@jest/environment": "^27.2.2",
         "@jest/types": "^27.1.1",
-        "expect": "^27.2.1"
+        "expect": "^27.2.2"
       }
     },
     "@jest/reporters": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.1.tgz",
-      "integrity": "sha512-ILqR+bIIBlhaHjDtQR/0Z20YkKAQVM+NVRuJLaWFCoRx/rKQQSxG01ZLiLV0MsA6wkBHf6J9fzFuXp0k5l7epw==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.2.tgz",
+      "integrity": "sha512-ufwZ8XoLChEfPffDeVGroYbhbcYPom3zKDiv4Flhe97rr/o2IfUXoWkDUDoyJ3/V36RFIMjokSu0IJ/pbFtbHg==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.2.0",
-        "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.1",
+        "@jest/console": "^27.2.2",
+        "@jest/test-result": "^27.2.2",
+        "@jest/transform": "^27.2.2",
         "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -589,10 +589,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.2.0",
-        "jest-resolve": "^27.2.0",
+        "jest-haste-map": "^27.2.2",
+        "jest-resolve": "^27.2.2",
         "jest-util": "^27.2.0",
-        "jest-worker": "^27.2.0",
+        "jest-worker": "^27.2.2",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -612,33 +612,33 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.2.0.tgz",
-      "integrity": "sha512-JPPqn8h0RGr4HyeY1Km+FivDIjTFzDROU46iAvzVjD42ooGwYoqYO/MQTilhfajdz6jpVnnphFrKZI5OYrBONA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.2.2.tgz",
+      "integrity": "sha512-yENoDEoWlEFI7l5z7UYyJb/y5Q8RqbPd4neAVhKr6l+vVaQOPKf8V/IseSMJI9+urDUIxgssA7RGNyCRhGjZvw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.2.0",
+        "@jest/console": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.1.tgz",
-      "integrity": "sha512-fWcEgWQXgvU4DFY5YHfQsGwqfJWyuCUzdOzLZTYtyLB3WK1mFPQGYAszM7mCEZjyVon5XRuCa+2/+hif/uMucQ==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.2.tgz",
+      "integrity": "sha512-YnJqwNQP2Zeu0S4TMqkxg6NN7Y1EFq715n/nThNKrvIS9wmRZjDt2XYqsHbuvhAFjshi0iKDQ813NewFITBH+Q==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.2.0",
+        "@jest/test-result": "^27.2.2",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.2.0",
-        "jest-runtime": "^27.2.1"
+        "jest-haste-map": "^27.2.2",
+        "jest-runtime": "^27.2.2"
       }
     },
     "@jest/transform": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.1.tgz",
-      "integrity": "sha512-xmB5vh81KK8DiiCMtI5vI59mP+GggNmc9BiN+fg4mKdQHV369+WuZc1Lq2xWFCOCsRPHt24D9h7Idp4YaMB1Ww==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.2.tgz",
+      "integrity": "sha512-l4Z/7PpajrOjCiXLWLfMY7fgljY0H8EwW7qdzPXXuv2aQF8kY2+Uyj3O+9Popnaw1V7JCw32L8EeI/thqFDkPA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
@@ -648,7 +648,7 @@
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.2.0",
+        "jest-haste-map": "^27.2.2",
         "jest-regex-util": "^27.0.6",
         "jest-util": "^27.2.0",
         "micromatch": "^4.0.4",
@@ -770,15 +770,15 @@
       }
     },
     "@types/node": {
-      "version": "16.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
-      "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA==",
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+      "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w==",
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -949,12 +949,12 @@
       }
     },
     "babel-jest": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.1.tgz",
-      "integrity": "sha512-kkaekSJHew1zfDW3cA2QiSBPg4uiLpiW0OwJKqFv0r2/mFgym/IBn7hxPntL6FvS66G/ROh+lz4pRiCJAH1/UQ==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.2.tgz",
+      "integrity": "sha512-XNFNNfGKnZXzhej7TleVP4s9ktH5JjRW8Rmcbb223JJwKB/gmTyeWN0JfiPtSgnjIjDXtKNoixiy0QUHtv3vFA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.2.1",
+        "@jest/transform": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
@@ -1056,16 +1056,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-      "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001254",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.830",
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
       }
     },
     "bser": {
@@ -1106,10 +1106,13 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001258",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
-      "dev": true
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+      "dev": true,
+      "requires": {
+        "nanocolors": "^0.1.0"
+      }
     },
     "chalk": {
       "version": "4.1.1",
@@ -1216,12 +1219,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true
     },
     "combined-stream": {
@@ -1371,9 +1368,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.845",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz",
-      "integrity": "sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==",
+      "version": "1.3.851",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.851.tgz",
+      "integrity": "sha512-Ak970eGtRSoHTaJkoDjdkeXYetbwm5Bl9pN/nPOQ3QzLfw1EWRjReOlWUra6o58SVgxfpwOT9U2P1BUXoJ57dw==",
       "dev": true
     },
     "emittery": {
@@ -1685,16 +1682,16 @@
       "dev": true
     },
     "expect": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.1.tgz",
-      "integrity": "sha512-ekOA2mBtT2phxcoPVHCXIzbJxCvRXhx2fr7m28IgGdZxUOh8UvxvoRz1FcPlfgZMpE92biHB6woIcAKXqR28hA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.2.tgz",
+      "integrity": "sha512-sjHBeEk47/eshN9oLbvPJZMgHQihOXXQzSMPCJ4MqKShbU9HOVFSNHEEU4dp4ujzxFSiNvPFzB2AMOFmkizhvA==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.2.0",
-        "jest-message-util": "^27.2.0",
+        "jest-matcher-utils": "^27.2.2",
+        "jest-message-util": "^27.2.2",
         "jest-regex-util": "^27.0.6"
       },
       "dependencies": {
@@ -2009,9 +2006,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -2080,9 +2077,9 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz",
+      "integrity": "sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==",
       "dev": true
     },
     "istanbul-lib-instrument": {
@@ -2147,32 +2144,32 @@
       }
     },
     "jest": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.1.tgz",
-      "integrity": "sha512-0MyvNS7J1HbkeotYaqKNGioN+p1/AAPtI1Z8iwMtCBE+PwBT+M4l25D9Pve8/KdhktYLgZaGyyj9CoDytD+R2Q==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.2.tgz",
+      "integrity": "sha512-XAB/9akDTe3/V0wPNKWfP9Y/NT1QPiCqyRBYGbC66EA9EvgAzdaFEqhFGLaDJ5UP2yIyXUMtju9a9IMrlYbZTQ==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.2.1",
+        "@jest/core": "^27.2.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.2.1"
+        "jest-cli": "^27.2.2"
       },
       "dependencies": {
         "jest-cli": {
-          "version": "27.2.1",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.1.tgz",
-          "integrity": "sha512-IfxuGkBZS/ogY7yFvvD1dFidzQRXlSBHtUZQ3UTIHydzNMF4/ZRTdGFso6HkbCkemwLh4hnNybONexEqWmYwjw==",
+          "version": "27.2.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.2.tgz",
+          "integrity": "sha512-jbEythw22LR/IHYgNrjWdO74wO9wyujCxTMjbky0GLav4rC4y6qDQr4TqQ2JPP51eDYJ2awVn83advEVSs5Brg==",
           "dev": true,
           "requires": {
-            "@jest/core": "^27.2.1",
-            "@jest/test-result": "^27.2.0",
+            "@jest/core": "^27.2.2",
+            "@jest/test-result": "^27.2.2",
             "@jest/types": "^27.1.1",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
-            "jest-config": "^27.2.1",
+            "jest-config": "^27.2.2",
             "jest-util": "^27.2.0",
-            "jest-validate": "^27.2.0",
+            "jest-validate": "^27.2.2",
             "prompts": "^2.0.1",
             "yargs": "^16.0.3"
           }
@@ -2191,71 +2188,71 @@
       }
     },
     "jest-circus": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.1.tgz",
-      "integrity": "sha512-9q/8X8DgJmW8IqXsJNnS2E28iarx990hf6D+frS3P0lB+avhFDD33alLwZzKgm45u0wvEi6iFh43WjNbp5fhjw==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.2.tgz",
+      "integrity": "sha512-8txlqs0EDrvPasCgwfLMkG0l3F4FxqQa6lxOsvYfOl04eSJjRw3F4gk9shakuC00nMD+VT+SMtFYXxe64f0VZw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.2.0",
-        "@jest/test-result": "^27.2.0",
+        "@jest/environment": "^27.2.2",
+        "@jest/test-result": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.2.1",
+        "expect": "^27.2.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.2.0",
-        "jest-matcher-utils": "^27.2.0",
-        "jest-message-util": "^27.2.0",
-        "jest-runtime": "^27.2.1",
-        "jest-snapshot": "^27.2.1",
+        "jest-each": "^27.2.2",
+        "jest-matcher-utils": "^27.2.2",
+        "jest-message-util": "^27.2.2",
+        "jest-runtime": "^27.2.2",
+        "jest-snapshot": "^27.2.2",
         "jest-util": "^27.2.0",
-        "pretty-format": "^27.2.0",
+        "pretty-format": "^27.2.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
       }
     },
     "jest-config": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.1.tgz",
-      "integrity": "sha512-BAOemP8udmFw9nkgaLAac7vXORdvrt4yrJWoh7uYb0nPZeSsu0kGwJU18SwtY4paq9fed5OgAssC3A+Bf4WMQA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.2.tgz",
+      "integrity": "sha512-2nhms3lp52ZpU0636bB6zIFHjDVtYxzFQIOHZjBFUeXcb6b41sEkWojbHaJ4FEIO44UbccTLa7tvNpiFCgPE7w==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.2.1",
+        "@jest/test-sequencer": "^27.2.2",
         "@jest/types": "^27.1.1",
-        "babel-jest": "^27.2.1",
+        "babel-jest": "^27.2.2",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.2.1",
-        "jest-environment-jsdom": "^27.2.0",
-        "jest-environment-node": "^27.2.0",
+        "jest-circus": "^27.2.2",
+        "jest-environment-jsdom": "^27.2.2",
+        "jest-environment-node": "^27.2.2",
         "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.2.1",
+        "jest-jasmine2": "^27.2.2",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.2.0",
-        "jest-runner": "^27.2.1",
+        "jest-resolve": "^27.2.2",
+        "jest-runner": "^27.2.2",
         "jest-util": "^27.2.0",
-        "jest-validate": "^27.2.0",
+        "jest-validate": "^27.2.2",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.2"
       }
     },
     "jest-diff": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.0.tgz",
-      "integrity": "sha512-QSO9WC6btFYWtRJ3Hac0sRrkspf7B01mGrrQEiCW6TobtViJ9RWL0EmOs/WnBsZDsI/Y2IoSHZA2x6offu0sYw==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.2.tgz",
+      "integrity": "sha512-o3LaDbQDSaMJif4yztJAULI4xVatxbBasbKLbEw3K8CiRdDdbxMrLArS9EKDHQFYh6Tgfrm1PC2mIYR1xhu0hQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.2"
       }
     },
     "jest-docblock": {
@@ -2268,26 +2265,26 @@
       }
     },
     "jest-each": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.2.0.tgz",
-      "integrity": "sha512-biDmmUQjg+HZOB7MfY2RHSFL3j418nMoC3TK3pGAj880fQQSxvQe1y2Wy23JJJNUlk6YXiGU0yWy86Le1HBPmA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.2.2.tgz",
+      "integrity": "sha512-ZCDhkvwHeXHsxoFxvW43fabL18iLiVDxaipG5XWG7dSd+XWXXpzMQvBWYT9Wvzhg5x4hvrLQ24LtiOKw3I09xA==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
         "jest-util": "^27.2.0",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.2"
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.2.0.tgz",
-      "integrity": "sha512-wNQJi6Rd/AkUWqTc4gWhuTIFPo7tlMK0RPZXeM6AqRHZA3D3vwvTa9ktAktyVyWYmUoXdYstOfyYMG3w4jt7eA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.2.2.tgz",
+      "integrity": "sha512-mzCLEdnpGWDJmNB6WIPLlZM+hpXdeiya9TryiByqcUdpliNV1O+LGC2SewzjmB4IblabGfvr3KcPN0Nme2wnDw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.2.0",
-        "@jest/fake-timers": "^27.2.0",
+        "@jest/environment": "^27.2.2",
+        "@jest/fake-timers": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "jest-mock": "^27.1.1",
@@ -2296,13 +2293,13 @@
       }
     },
     "jest-environment-node": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.2.0.tgz",
-      "integrity": "sha512-WbW+vdM4u88iy6Q3ftUEQOSgMPtSgjm3qixYYK2AKEuqmFO2zmACTw1vFUB0qI/QN88X6hA6ZkVKIdIWWzz+yg==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.2.2.tgz",
+      "integrity": "sha512-XgUscWs6H6UNqC96/QJjmUGZzzpql/JyprLSXVu7wkgM8tjbJdEkSqwrVAvJPm1yu526ImrmsIoh2BTHxkwL/g==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.2.0",
-        "@jest/fake-timers": "^27.2.0",
+        "@jest/environment": "^27.2.2",
+        "@jest/fake-timers": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "jest-mock": "^27.1.1",
@@ -2316,9 +2313,9 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.2.0.tgz",
-      "integrity": "sha512-laFet7QkNlWjwZtMGHCucLvF8o9PAh2cgePRck1+uadSM4E4XH9J4gnx4do+a6do8ZV5XHNEAXEkIoNg5XUH2Q==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.2.2.tgz",
+      "integrity": "sha512-kaKiq+GbAvk6/sq++Ymor4Vzk6+lr0vbKs2HDVPdkKsHX2lIJRyvhypZG/QsNfQnROKWIZSpUpGuv2HySSosvA==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
@@ -2331,63 +2328,63 @@
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
         "jest-util": "^27.2.0",
-        "jest-worker": "^27.2.0",
+        "jest-worker": "^27.2.2",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       }
     },
     "jest-jasmine2": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.1.tgz",
-      "integrity": "sha512-3vytj3+S49+XYsxGJyjlchDo4xblYzjDY4XK7pV2IAdspbMFOpmeNMOeDonYuvlbUtcV8yrFLA6XtliXapDmMA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.2.tgz",
+      "integrity": "sha512-SczhZNfmZID9HbJ1GHhO4EzeL/PMRGeAUw23ddPUdd6kFijEZpT2yOxyNCBUKAsVQ/14OB60kjgnbuFOboZUNg==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.2.0",
+        "@jest/environment": "^27.2.2",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.2.0",
+        "@jest/test-result": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.2.1",
+        "expect": "^27.2.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.2.0",
-        "jest-matcher-utils": "^27.2.0",
-        "jest-message-util": "^27.2.0",
-        "jest-runtime": "^27.2.1",
-        "jest-snapshot": "^27.2.1",
+        "jest-each": "^27.2.2",
+        "jest-matcher-utils": "^27.2.2",
+        "jest-message-util": "^27.2.2",
+        "jest-runtime": "^27.2.2",
+        "jest-snapshot": "^27.2.2",
         "jest-util": "^27.2.0",
-        "pretty-format": "^27.2.0",
+        "pretty-format": "^27.2.2",
         "throat": "^6.0.1"
       }
     },
     "jest-leak-detector": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.2.0.tgz",
-      "integrity": "sha512-e91BIEmbZw5+MHkB4Hnrq7S86coTxUMCkz4n7DLmQYvl9pEKmRx9H/JFH87bBqbIU5B2Ju1soKxRWX6/eGFGpA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.2.2.tgz",
+      "integrity": "sha512-fQIYKkhXUs/4EpE4wO1AVsv7aNH3o0km1BGq3vxvSfYdwG9GLMf+b0z/ghLmBYNxb+tVpm/zv2caoKm3GfTazg==",
       "dev": true,
       "requires": {
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.2"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.0.tgz",
-      "integrity": "sha512-F+LG3iTwJ0gPjxBX6HCyrARFXq6jjiqhwBQeskkJQgSLeF1j6ui1RTV08SR7O51XTUhtc8zqpDj8iCG4RGmdKw==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.2.tgz",
+      "integrity": "sha512-xN3wT4p2i9DGB6zmL3XxYp5lJmq9Q6ff8XKlMtVVBS2SAshmgsPBALJFQ8dWRd2G/xf5q/N0SD0Mipt8QBA26A==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.2.0",
+        "jest-diff": "^27.2.2",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.2"
       }
     },
     "jest-message-util": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.0.tgz",
-      "integrity": "sha512-y+sfT/94CiP8rKXgwCOzO1mUazIEdEhrLjuiu+RKmCP+8O/TJTSne9dqQRbFIHBtlR2+q7cddJlWGir8UATu5w==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.2.tgz",
+      "integrity": "sha512-/iS5/m2FSF7Nn6APFoxFymJpyhB/gPf0CJa7uFSkbYaWvrADUfQ9NTsuyjpszKErOS2/huFs44ysWhlQTKvL8Q==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
@@ -2396,7 +2393,7 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.2.0",
+        "pretty-format": "^27.2.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
@@ -2424,44 +2421,44 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.2.0.tgz",
-      "integrity": "sha512-v09p9Ib/VtpHM6Cz+i9lEAv1Z/M5NVxsyghRHRMEUOqwPQs3zwTdwp1xS3O/k5LocjKiGS0OTaJoBSpjbM2Jlw==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.2.2.tgz",
+      "integrity": "sha512-tfbHcBs/hJTb3fPQ/3hLWR+TsLNTzzK98TU+zIAsrL9nNzWfWROwopUOmiSUqmHMZW5t9au/433kSF2/Af+tTw==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
         "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.2.0",
+        "jest-haste-map": "^27.2.2",
         "jest-pnp-resolver": "^1.2.2",
         "jest-util": "^27.2.0",
-        "jest-validate": "^27.2.0",
+        "jest-validate": "^27.2.2",
         "resolve": "^1.20.0",
         "slash": "^3.0.0"
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.1.tgz",
-      "integrity": "sha512-9bKEwmz4YshGPjGZAVZOVw6jt7pq2/FjWJmyhnWhvDuiRCHVZBcJhycinX+e/EJ7jafsq26bTpzBIQas3xql1g==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.2.tgz",
+      "integrity": "sha512-nvJS+DyY51HHdZnMIwXg7fimQ5ylFx4+quQXspQXde2rXYy+4v75UYoX/J65Ln8mKCNc6YF8HEhfGaRBOrxxHg==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
         "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.2.1"
+        "jest-snapshot": "^27.2.2"
       }
     },
     "jest-runner": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.1.tgz",
-      "integrity": "sha512-USHitkUUzcB3Y5mRdzlp+KHgRRR2VsXDq5OeATuDmq1qXfT/RwwnQykUhn+KVx3FotxK3pID74UY7o6HYIR8vA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.2.tgz",
+      "integrity": "sha512-+bUFwBq+yTnvsOFuxetoQtkuOnqdAk2YuIGjlLmc7xLAXn/V1vjhXrLencgij0BUTTUvG9Aul3+5XDss4Wa8Eg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.2.0",
-        "@jest/environment": "^27.2.0",
-        "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.1",
+        "@jest/console": "^27.2.2",
+        "@jest/environment": "^27.2.2",
+        "@jest/test-result": "^27.2.2",
+        "@jest/transform": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -2469,32 +2466,32 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-docblock": "^27.0.6",
-        "jest-environment-jsdom": "^27.2.0",
-        "jest-environment-node": "^27.2.0",
-        "jest-haste-map": "^27.2.0",
-        "jest-leak-detector": "^27.2.0",
-        "jest-message-util": "^27.2.0",
-        "jest-resolve": "^27.2.0",
-        "jest-runtime": "^27.2.1",
+        "jest-environment-jsdom": "^27.2.2",
+        "jest-environment-node": "^27.2.2",
+        "jest-haste-map": "^27.2.2",
+        "jest-leak-detector": "^27.2.2",
+        "jest-message-util": "^27.2.2",
+        "jest-resolve": "^27.2.2",
+        "jest-runtime": "^27.2.2",
         "jest-util": "^27.2.0",
-        "jest-worker": "^27.2.0",
+        "jest-worker": "^27.2.2",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       }
     },
     "jest-runtime": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.1.tgz",
-      "integrity": "sha512-QJNnwL4iteDE/Jq4TfQK7AjhPoUZflBKTtUIkRnFYFkTAZTP/o8k7ekaROiVjmo+NYop5+DQPqX6pz4vWbZSOQ==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.2.tgz",
+      "integrity": "sha512-PtTHCK5jT+KrIpKpjJsltu/dK5uGhBtTNLOk1Z+ZD2Jrxam2qQsOqDFYLszcK0jc2TLTNsrVpclqSftn7y3aXA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.2.0",
-        "@jest/environment": "^27.2.0",
-        "@jest/fake-timers": "^27.2.0",
-        "@jest/globals": "^27.2.1",
+        "@jest/console": "^27.2.2",
+        "@jest/environment": "^27.2.2",
+        "@jest/fake-timers": "^27.2.2",
+        "@jest/globals": "^27.2.2",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.1",
+        "@jest/test-result": "^27.2.2",
+        "@jest/transform": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
@@ -2504,14 +2501,14 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.2.0",
-        "jest-message-util": "^27.2.0",
+        "jest-haste-map": "^27.2.2",
+        "jest-message-util": "^27.2.2",
         "jest-mock": "^27.1.1",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.2.0",
-        "jest-snapshot": "^27.2.1",
+        "jest-resolve": "^27.2.2",
+        "jest-snapshot": "^27.2.2",
         "jest-util": "^27.2.0",
-        "jest-validate": "^27.2.0",
+        "jest-validate": "^27.2.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.0.3"
@@ -2528,9 +2525,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.1.tgz",
-      "integrity": "sha512-8CTg2YrgZuQbPHW7G0YvLTj4yTRXLmSeEO+ka3eC5lbu5dsTRyoDNS1L7x7EFUTyYQhFH9HQG1/TNlbUgR9Lug==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.2.tgz",
+      "integrity": "sha512-7ODSvULMiiOVuuLvLZpDlpqqTqX9hDfdmijho5auVu9qRYREolvrvgH4kSNOKfcqV3EZOTuLKNdqsz1PM20PQA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -2539,23 +2536,23 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.2.1",
+        "@jest/transform": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.2.1",
+        "expect": "^27.2.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.2.0",
+        "jest-diff": "^27.2.2",
         "jest-get-type": "^27.0.6",
-        "jest-haste-map": "^27.2.0",
-        "jest-matcher-utils": "^27.2.0",
-        "jest-message-util": "^27.2.0",
-        "jest-resolve": "^27.2.0",
+        "jest-haste-map": "^27.2.2",
+        "jest-matcher-utils": "^27.2.2",
+        "jest-message-util": "^27.2.2",
+        "jest-resolve": "^27.2.2",
         "jest-util": "^27.2.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.2.0",
+        "pretty-format": "^27.2.2",
         "semver": "^7.3.2"
       },
       "dependencies": {
@@ -2585,9 +2582,9 @@
       }
     },
     "jest-validate": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.2.0.tgz",
-      "integrity": "sha512-uIEZGkFKk3+4liA81Xu0maG5aGDyPLdp+4ed244c+Ql0k3aLWQYcMbaMLXOIFcb83LPHzYzqQ8hwNnIxTqfAGQ==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.2.2.tgz",
+      "integrity": "sha512-01mwTAs2kgDuX98Ua3Xhdhp5lXsLU4eyg6k56adTtrXnU/GbLd9uAsh5nc4MWVtUXMeNmHUyEiD4ibLqE8MuNw==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
@@ -2595,7 +2592,7 @@
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.2"
       },
       "dependencies": {
         "camelcase": {
@@ -2607,12 +2604,12 @@
       }
     },
     "jest-watcher": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.2.0.tgz",
-      "integrity": "sha512-SjRWhnr+qO8aBsrcnYIyF+qRxNZk6MZH8TIDgvi+VlsyrvOyqg0d+Rm/v9KHiTtC9mGGeFi9BFqgavyWib6xLg==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.2.2.tgz",
+      "integrity": "sha512-7HJwZq06BCfM99RacCVzXO90B20/dNJvq+Ouiu/VrFdFRCpbnnqlQUEk4KAhBSllgDrTPgKu422SCF5KKBHDRA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.2.0",
+        "@jest/test-result": "^27.2.2",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -2622,9 +2619,9 @@
       }
     },
     "jest-worker": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.0.tgz",
-      "integrity": "sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.2.tgz",
+      "integrity": "sha512-aG1xq9KgWB2CPC8YdMIlI8uZgga2LFNcGbHJxO8ctfXAydSaThR4EewKQGg3tBOC+kS3vhPGgymsBdi9VINjPw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -2888,6 +2885,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3065,17 +3068,23 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.0.tgz",
-      "integrity": "sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==",
+      "version": "27.2.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.2.tgz",
+      "integrity": "sha512-+DdLh+rtaElc2SQOE/YPH8k2g3Rf2OXWEpy06p8Szs3hdVSYD87QOOlYRHWAeb/59XTmeVmRKvDD0svHqf6ycA==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
-        "ansi-regex": "^5.0.0",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -3587,9 +3596,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
-      "integrity": "sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
+      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -933,9 +933,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.991.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.991.0.tgz",
-      "integrity": "sha512-TybluMJhRBZ0h5HGupHPTfamwtsJlW56HddJpMbsIjvmh4LGupajrkEwLQYW7osFXQ1S/xuE+0QIy6vWgOpT0g==",
+      "version": "2.996.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.996.0.tgz",
+      "integrity": "sha512-LZcus/r/36lwmGhRcwwllzQUucZ6sozDt3r78lXqdaQzZNbv44K44nXsqCPH2UpTcznrVUSJOW+o5s8yEbKFzg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -887,9 +887,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -3079,12 +3079,6 @@
         "react-is": "^17.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -948,6 +948,14 @@
         "xml2js": "0.4.19"
       }
     },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "babel-jest": {
       "version": "27.2.2",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.2.tgz",
@@ -1773,6 +1781,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
     },
     "form-data": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/aws-actions/configure-aws-credentials#readme",
   "dependencies": {
     "@actions/core": "^1.5.0",
-    "aws-sdk": "^2.996.0"
+    "aws-sdk": "^2.988.0",
+    "axios": "^0.21.4"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/aws-actions/configure-aws-credentials#readme",
   "dependencies": {
     "@actions/core": "^1.5.0",
-    "aws-sdk": "^2.991.0"
+    "aws-sdk": "^2.996.0"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",
     "eslint": "^7.32.0",
-    "jest": "^27.2.1"
+    "jest": "^27.2.2"
   }
 }


### PR DESCRIPTION
*Description of changes:*

Added the ability to use GitHub provided OIDC token. If a user supplies a Role Arn and doesn't supply either an Access Key Id or a WebIdentityTokenFile we will attempt to load the OIDC Token from the environment variable provided by GitHub. If the Environment variable isn't set (because this could be running in a self-hosted runner) then we will fall back to the default credential provider as previously outlined in the `README.md`.

Updated the `README.md` to remove most mentions of using IAM Users as we expect future users to rely on the OIDC implementation, but the IAM User use-case is still defined (it's just not highlighted any more in the documentation).

Thanks to @aidansteele for the reference implmentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
