### PR TITLE
fix: Updated token retrieval to use new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Resources:
     Condition: CreateOIDCProvider
     Properties:
       Url: https://vstoken.actions.githubusercontent.com
-      ClientIdList: [sigstore]
+      ClientIdList: ['sts.amazonaws.com']
       ThumbprintList: [a031c46782e6e6c662c2c87c76da9aa62ccabd8e]
 
 Outputs:

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ const aws = require('aws-sdk');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const axios = require('axios');
 
 // The max time that a GitHub action is allowed to run is 6 hours.
 // That seems like a reasonable default to use if no role duration is defined.
@@ -185,21 +184,6 @@ async function exportAccountId(maskAccountId, region) {
   return accountId;
 }
 
-async function getWebIdentityToken() {
-  const isDefined = i => !!i;
-  const {ACTIONS_ID_TOKEN_REQUEST_URL, ACTIONS_ID_TOKEN_REQUEST_TOKEN} = process.env;
-
-  assert(
-      [ACTIONS_ID_TOKEN_REQUEST_URL, ACTIONS_ID_TOKEN_REQUEST_TOKEN].every(isDefined),
-      'Missing required environment value. Are you running in GitHub Actions?'
-  );
-  const { data } = await axios.get(`${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sigstore`, {
-    headers: {"Authorization": `bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}`}
-    }
-  );
-  return data.value;
-}
-
 function loadCredentials() {
   // Force the SDK to re-resolve credentials with the default provider chain.
   //
@@ -303,7 +287,7 @@ async function run() {
     let sourceAccountId;
     let webIdentityToken;
     if(useGitHubOIDCProvider()) {
-      webIdentityToken = await getWebIdentityToken();
+      webIdentityToken = await core.getIDToken('sts.amazonaws.com');
       roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || DEFAULT_ROLE_DURATION_FOR_OIDC_ROLES;
       // We don't validate the credentials here because we don't have them yet when using OIDC.
     } else {

--- a/index.test.js
+++ b/index.test.js
@@ -2,10 +2,8 @@ const core = require('@actions/core');
 const assert = require('assert');
 const aws = require('aws-sdk');
 const run = require('./index.js');
-const axios = require('axios');
 
 jest.mock('@actions/core');
-jest.mock("axios");
 
 const FAKE_ACCESS_KEY_ID = 'MY-AWS-ACCESS-KEY-ID';
 const FAKE_SECRET_ACCESS_KEY = 'MY-AWS-SECRET-ACCESS-KEY';
@@ -73,11 +71,6 @@ jest.mock('fs', () => {
     };
 });
 
-
-jest.mock('axios', () => ({
-  get: jest.fn(() => Promise.resolve({ data: { value: "testtoken" }})),
-}));
-
 describe('Configure AWS Credentials', () => {
     const OLD_ENV = process.env;
 
@@ -90,6 +83,12 @@ describe('Configure AWS Credentials', () => {
         core.getInput = jest
             .fn()
             .mockImplementation(mockGetInput(DEFAULT_INPUTS));
+
+        core.getIDToken = jest
+            .fn()
+            .mockImplementation(() => {
+                return "testtoken"
+            });
 
         mockStsCallerIdentity.mockReset();
         mockStsCallerIdentity
@@ -571,7 +570,6 @@ describe('Configure AWS Credentials', () => {
     test('only role arn and region provided to use GH OIDC Token', async () => {
         process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = 'test-token';
         process.env.ACTIONS_ID_TOKEN_REQUEST_URL = 'https://www.example.com/token/endpoint';
-        axios.get.mockImplementation(() => Promise.resolve({ data: {value: "testtoken"} }));
         core.getInput = jest
             .fn()
             .mockImplementation(mockGetInput({'role-to-assume': ROLE_ARN, 'aws-region': FAKE_REGION}));
@@ -592,7 +590,6 @@ describe('Configure AWS Credentials', () => {
         const CUSTOM_ROLE_DURATION = 1234;
         process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = 'test-token';
         process.env.ACTIONS_ID_TOKEN_REQUEST_URL = 'https://www.example.com/token/endpoint';
-        axios.get.mockImplementation(() => Promise.resolve({ data: {value: "testtoken"} }));
         core.getInput = jest
             .fn()
             .mockImplementation(mockGetInput({'role-to-assume': ROLE_ARN, 'aws-region': FAKE_REGION, 'role-duration-seconds': CUSTOM_ROLE_DURATION}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -948,6 +948,14 @@
         "xml2js": "0.4.19"
       }
     },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "babel-jest": {
       "version": "27.2.2",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.2.tgz",
@@ -1773,6 +1781,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
     },
     "form-data": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/aws-actions/configure-aws-credentials#readme",
   "dependencies": {
     "@actions/core": "^1.5.0",
-    "aws-sdk": "^2.996.0"
+    "aws-sdk": "^2.988.0",
+    "axios": "^0.21.4"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updated the OIDC JWT fetching process to use the new API
- replaced `sigstore` with `sts.amazon.aws` as the audience to reflect OIDC best practices for the audience to reflect the party that will be receiving the JWT.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
