### PR TITLE
Update github oidc token url in cfn template

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ Resources:
               Federated: !Ref GithubOidc
             Condition:
               StringLike:
-                vstoken.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepositoryName}:*
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepositoryName}:*
 
   GithubOidc:
     Type: AWS::IAM::OIDCProvider
     Condition: CreateOIDCProvider
     Properties:
-      Url: https://vstoken.actions.githubusercontent.com
+      Url: https://token.actions.githubusercontent.com
       ClientIdList: [sigstore]
       ThumbprintList: [a031c46782e6e6c662c2c87c76da9aa62ccabd8e]
 


### PR DESCRIPTION
This commit updates the example "IAM Role CloudFormation Template" with the new github oidc token url.
See issue #280 for further explanation: https://github.com/aws-actions/configure-aws-credentials/issues/280

*Issue #, if available:* [280](https://github.com/aws-actions/configure-aws-credentials/issues/280)

*Description of changes:*

Updates the example "IAM Role CloudFormation Template" with the new github oidc token url.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
