### PR TITLE
fix: Update GH Action OIDC url

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Resources:
     Type: AWS::IAM::OIDCProvider
     Condition: CreateOIDCProvider
     Properties:
-      Url: https://vstoken.actions.githubusercontent.com
+      Url: https://token.actions.githubusercontent.com
       ClientIdList: [sigstore]
       ThumbprintList: [a031c46782e6e6c662c2c87c76da9aa62ccabd8e]
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Resources:
               Federated: !Ref GithubOidc
             Condition:
               StringLike:
-                vstoken.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepositoryName}:*
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepositoryName}:*
 
   GithubOidc:
     Type: AWS::IAM::OIDCProvider


### PR DESCRIPTION
GH Action OIDC url seems to be updated to `https://token.actions.githubusercontent.com` from `https://vstoken.actions.githubusercontent.com`

<img width="754" alt="error" src="https://user-images.githubusercontent.com/89082196/136377456-996854d8-cfa9-40ec-85cf-9ff104cc211f.png">


