### PR TITLE
Fix: Revert eslint version to 7.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",
-    "eslint": "^8.1.0",
+    "eslint": "^7.32.0",
     "jest": "^27.3.1"
   }
 }


### PR DESCRIPTION
Description - 
Reverting eslint version to 7.32.0. The new version of `eslint 8.1.0`  is not supported by `nodejs 10` which is being used by `aws/codebuild/standard:2.0` image  

Background - Dependabot updated eslint version from 7.32.0 to 8.1.0