### PR TITLE
fix: Fix description of role-duration-seconds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,8 @@ inputs:
       assume an IAM role using a web identity. E.g., from within an Amazon EKS worker node
     required: false
   role-duration-seconds:
-    description: "Role duration in seconds (default: 6 hours)"
+    description: >-
+      Role duration in seconds. The default duration is 1 hour when using the OIDC provider or 6 hours when using an IAM User.
     required: false
   role-session-name:
     description: 'Role session name (default: GitHubActions)'

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,8 @@ inputs:
     required: false
   role-duration-seconds:
     description: >-
-      Role duration in seconds. The default duration is 1 hour when using the OIDC provider or 6 hours when using an IAM User.
+      Role duration in seconds. The default duration is 1 hour when using the OIDC provider or
+      6 hours when using an IAM User.
     required: false
   role-session-name:
     description: 'Role session name (default: GitHubActions)'


### PR DESCRIPTION
*Description of changes:*

This PR adds the description of the default duration when using OIDC provider.

As described in [README.md](https://github.com/aws-actions/configure-aws-credentials#assuming-a-role), the default session duration can be 1 hour when using the OIDC provider.
However, the description of `role-duration-seconds` in action.yml seems to explain the default is 6 hours in all cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
