### PR TITLE
fix: OIDC Parallel Requests error

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,6 +236,29 @@ function getStsClient(region) {
   });
 }
 
+let defaultSleep = function (ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+let sleep = defaultSleep;
+
+// retryAndBackoff retries with exponential backoff the promise if the error isRetryable upto maxRetries time.
+const retryAndBackoff = async (fn, isRetryable, retries = 0, maxRetries = 12, base = 50) => {
+  try {
+    return await fn();
+  } catch (err) {
+    if (!isRetryable) {
+      throw err;
+    }
+    // It's retryable, so sleep and retry.
+    await sleep(Math.random() * (Math.pow(2, retries) * base) );
+    retries += 1;
+    if (retries === maxRetries) {
+      throw err;
+    }
+    return await retryAndBackoff(fn, isRetryable, retries, maxRetries, base);
+  }
+}
+
 async function run() {
   try {
     // Get inputs
@@ -303,17 +326,18 @@ async function run() {
 
     // Get role credentials if configured to do so
     if (roleToAssume) {
-      const roleCredentials = await assumeRole({
-        sourceAccountId,
-        region,
-        roleToAssume,
-        roleExternalId,
-        roleDurationSeconds,
-        roleSessionName,
-        roleSkipSessionTagging,
-        webIdentityTokenFile,
-        webIdentityToken
-      });
+      const roleCredentials = await retryAndBackoff(
+          async () => { return await assumeRole({
+            sourceAccountId,
+            region,
+            roleToAssume,
+            roleExternalId,
+            roleDurationSeconds,
+            roleSessionName,
+            roleSkipSessionTagging,
+            webIdentityTokenFile,
+            webIdentityToken
+          }) }, true);
       exportCredentials(roleCredentials);
       // We need to validate the credentials in 2 of our use-cases
       // First: self-hosted runners. If the GITHUB_ACTIONS environment variable
@@ -337,7 +361,14 @@ async function run() {
   }
 }
 
-module.exports = run;
+exports.withSleep = function (s) {
+  sleep = s;
+};
+exports.reset = function () {
+  sleep = defaultSleep;
+};
+
+exports.run = run
 
 /* istanbul ignore next */
 if (require.main === module) {


### PR DESCRIPTION
This PR fixes the issue #299 

Description - When multiple workflows try to assume a role at the same time then OIDC provider returns an error - `Couldn't retrieve verification key from your identity provider, please reference AssumeRoleWithWebIdentity documentation for requirements`

We now have a fix which will make sure that these parallel requests will retry assuming a role if it fails to do so. `retryAndBackoff` logic will take care of retrial of assuming a role at random times so that no 2 parallel requests will try to get credentials from OIDC provider at the same time. 

Screenshots - 
We have tried running 40 parallel workflows and all of them were able to assume a role successfully

<img width="1273" alt="Screen Shot 2022-01-10 at 2 26 31 PM" src="https://user-images.githubusercontent.com/18301288/148849053-be367091-8b98-47bc-81aa-18136b33c524.png">

<img width="1274" alt="Screen Shot 2022-01-10 at 2 29 27 PM" src="https://user-images.githubusercontent.com/18301288/148849173-5db6d3ba-73c2-43e7-917c-c0f54deae86b.png">

