### PR TITLE
fix: Update `token.actions.githubusercontent.com` thumbprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Resources:
       ClientIdList: 
         - sts.amazonaws.com
       ThumbprintList:
-        - 15e29108718111e59b3dad31954647e3c344a231
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
 
 Outputs:
   Role:

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Resources:
       ClientIdList: 
         - sts.amazonaws.com
       ThumbprintList:
-        - a031c46782e6e6c662c2c87c76da9aa62ccabd8e
+        - 15e29108718111e59b3dad31954647e3c344a231
 
 Outputs:
   Role:


### PR DESCRIPTION
The recommendation to hard code this in cloudformation doesn't seem very good. This is going to break every few months when github rotates their cert. Are there any AWS best practices around this. Just updating it in cloudformation and re-deploying isn't going to cut it if your cloudformation file is itself deployed via github actions...

EDIT: GitHub have confirmed the new hash, validating this change - https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/.