### PR TITLE
fix: Update README.md with new thumbprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Resources:
       ClientIdList: 
         - sts.amazonaws.com
       ThumbprintList:
-        - a031c46782e6e6c662c2c87c76da9aa62ccabd8e
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
 
 Outputs:
   Role:


### PR DESCRIPTION
GitHub updated their thumbprint recently, and so the OCID provider
needs to be updated to take this into account.

The blog announcing this is as below, but essentially an update of:

a031c46782e6e6c662c2c87c76da9aa62ccabd8e ->
6938fd4d98bab03faadb97b34396831e3780aea1

https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/

Fixes #357 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
