### PR TITLE
feat: Allow audience to be explicitly specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The default session duration is 1 hour when using the OIDC provider to directly 
 The default session duration is 6 hours when using an IAM User to assume an IAM Role (by providing an `aws-access-key-id`, `aws-secret-access-key`, and a `role-to-assume`) .
 If you would like to adjust this you can pass a duration to `role-duration-seconds`, but the duration cannot exceed the maximum that was defined when the IAM Role was created.
 The default session name is GitHubActions, and you can modify it by specifying the desired name in `role-session-name`.
+The default audience is `sts.amazonaws.com` which you can replace by specifying the desired audience name in `audience`.
 
 The following table describes which identity is used based on which values are supplied to the Action:
 
@@ -98,7 +99,6 @@ The following table describes which identity is used based on which values are s
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        audience: sts.amazonaws.com
         aws-region: us-east-2
         role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
         role-session-name: MySessionName
@@ -109,7 +109,6 @@ In this example, the Action will load the OIDC token from the GitHub-provided en
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        audience: sts.amazonaws.com
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-2
@@ -119,6 +118,19 @@ In this example, the Action will load the OIDC token from the GitHub-provided en
         role-session-name: MySessionName
 ```
 In this example, the secret `AWS_ROLE_TO_ASSUME` contains a string like `arn:aws:iam::123456789100:role/my-github-actions-role`.  To assume a role in the same account as the static credentials, you can simply specify the role name, like `role-to-assume: my-github-actions-role`.
+
+```yaml
+    - name: Configure AWS Credentials for Beta Customers
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        audience: beta-customers
+        aws-region: us-east-3
+        role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
+        role-session-name: MySessionName
+```
+In this example, the audience has been changed from the default to use a different audience name `beta-customers`. This can help ensure that the role can only affect those AWS accounts whose GitHub OIDC providers have explicitly opted in to the `beta-customers` label.
+
+Changing the default audience may be necessary when using non-default [AWS partitions](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 
 ### Sample IAM Role CloudFormation Template
 ```yaml

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The following table describes which identity is used based on which values are s
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
+        audience: sts.amazonaws.com
         aws-region: us-east-2
         role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
         role-session-name: MySessionName
@@ -108,6 +109,7 @@ In this example, the Action will load the OIDC token from the GitHub-provided en
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
+        audience: sts.amazonaws.com
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-2

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ branding:
   icon: 'cloud'
   color: 'orange'
 inputs:
+  audience:
+    default: 'sts.amazonaws.com'
+    description: 'The audience to use for the OIDC provider'
+    required: false
   aws-access-key-id:
     description: >-
       AWS Access Key ID. This input is required if running in the GitHub hosted environment.

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ async function assumeRole(params) {
   const isDefined = i => !!i;
 
   const {
-    audience,
     sourceAccountId,
     roleToAssume,
     roleExternalId,

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ async function assumeRole(params) {
   const isDefined = i => !!i;
 
   const {
+    audience,
     sourceAccountId,
     roleToAssume,
     roleExternalId,
@@ -263,6 +264,7 @@ async function run() {
   try {
     // Get inputs
     const accessKeyId = core.getInput('aws-access-key-id', { required: false });
+    const audience = core.getInput('audience', { required: false });
     const secretAccessKey = core.getInput('aws-secret-access-key', { required: false });
     const region = core.getInput('aws-region', { required: true });
     const sessionToken = core.getInput('aws-session-token', { required: false });
@@ -310,7 +312,7 @@ async function run() {
     let sourceAccountId;
     let webIdentityToken;
     if(useGitHubOIDCProvider()) {
-      webIdentityToken = await core.getIDToken('sts.amazonaws.com');
+      webIdentityToken = await core.getIDToken(audience);
       roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || DEFAULT_ROLE_DURATION_FOR_OIDC_ROLES;
       // We don't validate the credentials here because we don't have them yet when using OIDC.
     } else {


### PR DESCRIPTION
Allow the audience to be configured instead of defaulting to 'sts.amazonaws.com'.

It's desirable to be able to use different audiences to ensure that changes aren't enabled on the wrong location -- for example, you can use an audience of 'prod' in the production accounts and 'dev' in the development accounts.

By adding audience as an argument to the job, you can set a specific parameter in the with block, and the example has been updated to reflect this.

By the way, it's possible to configure both the role and the OICD provider with an 'either' clause, so you can use one of several audiences  -- but that somewhat defeats the point of using a non-default value :)

  "Action": "sts:AssumeRoleWithWebIdentity",
  "Condition": {
    "StringLike": {
      "token.actions.githubusercontent.com:sub": "repo:alblue/*",
      "token.actions.githubusercontent.com:aud": ["sts.amazonaws.com","alblue"]
    }

Furthermore this approach allows you to use the audience to allow for different sets roles to be enabled; you could have a dev audience that is only trusted by the GitHubDev role, and a prod audience that is only trusted by the GitHubProd role. The OICD audience could have both, but you'd then guarantee that the dev audience couldn't assume the GitHubProd role (and vice versa).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

fixes: #458, #457