### PR TITLE
Don't hide account ID in Actions logs by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: >-
       Whether to set the AWS account ID for these credentials as a secret value,
       so that it is masked in logs. Valid values are 'true' and 'false'.
-      Defaults to true
+      Defaults to false
     required: false
   role-to-assume:
     description: >-

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ async function exportAccountId(maskAccountId, region) {
   const sts = getStsClient(region);
   const identity = await sts.getCallerIdentity().promise();
   const accountId = identity.Account;
-  if (!maskAccountId || maskAccountId.toLowerCase() == 'true') {
+  if (maskAccountId.toLowerCase() == 'true') {
     core.setSecret(accountId);
   }
   core.setOutput('aws-account-id', accountId);
@@ -266,7 +266,7 @@ async function run() {
     const secretAccessKey = core.getInput('aws-secret-access-key', { required: false });
     const region = core.getInput('aws-region', { required: true });
     const sessionToken = core.getInput('aws-session-token', { required: false });
-    const maskAccountId = core.getInput('mask-aws-account-id', { required: false });
+    const maskAccountId = core.getInput('mask-aws-account-id', { required: false }) || 'false';
     const roleToAssume = core.getInput('role-to-assume', {required: false});
     const roleExternalId = core.getInput('role-external-id', { required: false });
     let roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || MAX_ACTION_RUNTIME;


### PR DESCRIPTION
*Description of changes:*


According to https://www.lastweekinaws.com/blog/are-aws-account-ids-sensitive-information/ which was confirmed with AWS:

> “Account IDs are not considered sensitive. Based on your feedback,
> we’ve started updating our documentation to make this more clear.”

This commit updates the 'mask-aws-account-id' input to default to
'false' if it is not provided.

I'm not sure whether this should be considered a breaking change or not? It is changing the contract, but I don't think in a security sensitive way. I could see other interpretations though.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Fixes https://github.com/aws-actions/configure-aws-credentials/issues/459
