### PR TITLE
Fix AWS China Region STS incorrect token audience 

### DIFF
--- a/index.js
+++ b/index.js
@@ -310,7 +310,15 @@ async function run() {
     let sourceAccountId;
     let webIdentityToken;
     if(useGitHubOIDCProvider()) {
-      webIdentityToken = await core.getIDToken('sts.amazonaws.com');
+      if(region === "cn-north-1"){
+        webIdentityToken = await core.getIDToken('sts.cn-north-1.amazonaws.com.cn');
+      }
+      else if (region === "cn-northwest-1"){
+        webIdentityToken = await core.getIDToken('sts.cn-northwest-1.amazonaws.com.cn');
+
+      }else {
+        webIdentityToken = await core.getIDToken('sts.amazonaws.com');
+      }
       roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || DEFAULT_ROLE_DURATION_FOR_OIDC_ROLES;
       // We don't validate the credentials here because we don't have them yet when using OIDC.
     } else {


### PR DESCRIPTION
*Issue #457 

*Description of changes:*
add the China AWS region to get the OIDC token.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
