### PR TITLE
Run action on node16 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,6 @@ outputs:
   aws-account-id:
     description: 'The AWS account ID for the provided credentials'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
*Issue #, if available:* #489

*Description of changes:* Makes the action run with the node16 runtime instead of node12.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
