### PR TITLE
fix: ensure that `validatecredentials` is not called when trying to use webidentitytokenfile

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ async function run() {
       webIdentityToken = await core.getIDToken(audience);
       roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || DEFAULT_ROLE_DURATION_FOR_OIDC_ROLES;
       // We don't validate the credentials here because we don't have them yet when using OIDC.
-    } else {
+    } else if (!webIdentityTokenFile) {
       // Regardless of whether any source credentials were provided as inputs,
       // validate that the SDK can actually pick up credentials.  This validates
       // cases where this action is on a self-hosted runner that doesn't have credentials
@@ -344,7 +344,7 @@ async function run() {
       // First: self-hosted runners. If the GITHUB_ACTIONS environment variable
       //  is set to `true` then we are NOT in a self-hosted runner.
       // Second: Customer provided credentials manually (IAM User keys stored in GH Secrets)
-      if (!process.env.GITHUB_ACTIONS || accessKeyId) {
+      if ((!process.env.GITHUB_ACTIONS || accessKeyId) && !webIdentityTokenFile) {
         await validateCredentials(roleCredentials.accessKeyId);
       }
       await exportAccountId(maskAccountId, region);

--- a/index.test.js
+++ b/index.test.js
@@ -560,7 +560,7 @@ describe('Configure AWS Credentials', () => {
             RoleSessionName: 'GitHubActions',
             DurationSeconds: 6 * 3600,
             WebIdentityToken: 'testpayload'
-        })
+        });
     });
 
     test('web identity token file provided with relative path', async () => {
@@ -574,7 +574,7 @@ describe('Configure AWS Credentials', () => {
             RoleSessionName: 'GitHubActions',
             DurationSeconds: 6 * 3600,
             WebIdentityToken: 'testpayload'
-        })
+        });
     });
 
     test('only role arn and region provided to use GH OIDC Token', async () => {


### PR DESCRIPTION
fixes: #124 

*Description of changes:* Adds a check to ensure that `webIdentityTokenFile` is not defined before `validateCredentials()` is called, as we want to use just the file if it's defined. Not checking this leads to failure if only `webIdentityTokenFile` is defined without access credentials

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/master/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
