### PR TITLE
fix: temporarily bump node version to 14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
     interval: weekly
     day: tuesday
   open-pull-requests-limit: 10
+  target-branch: 'master'
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: tuesday
+  open-pull-requests-limit: 10
+  target-branch: 'v1-node14'

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ queue_rules:
 pull_request_rules:
   - name: Automatically merge on CI success and review approval
     conditions:
-      - base~=master|integ-tests
+      - base~=master|v1-node14|integ-tests
       - "#approved-reviews-by>=1"
       - -approved-reviews-by~=author
       - status-success=Run Unit Tests
@@ -23,7 +23,7 @@ pull_request_rules:
 
   - name: Automatically approve and merge Dependabot PRs
     conditions:
-      - base=master
+      - base~=master|v1-node14
       - author=dependabot[bot]
       - status-success=Run Unit Tests
       - -title~=(WIP|wip)

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,6 @@ outputs:
   aws-account-id:
     description: 'The AWS account ID for the provided credentials'
 runs:
-  using: 'node12'
+  using: 'node14'
   main: 'dist/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
*Issue #, if available:* #489

*Description of changes:* Node 12 is EOL and we need to move to a more modern version. A comprehensive release is set for a new major version of this action which will use the most up to date version of node, but for now customers are getting warnings about Node 12 actions on GitHub. This is a temporary fix that will bump the runs to Node 16 while we work on v2. 

---

* [X] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/master/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
