### PR TITLE
fix: temporarily bump node version to 16

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,12 @@ updates:
     interval: weekly
     day: tuesday
   open-pull-requests-limit: 10
+  target-branch: 'master'
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: tuesday
+  open-pull-requests-limit: 10
+  target-branch: 'v1-node16'
+  

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,4 @@
+
 queue_rules:
   - name: default
     conditions:
@@ -7,7 +8,7 @@ queue_rules:
 pull_request_rules:
   - name: Automatically merge on CI success and review approval
     conditions:
-      - base~=master|integ-tests
+      - base~=master|v1-node16|integ-tests
       - "#approved-reviews-by>=1"
       - -approved-reviews-by~=author
       - status-success=Run Unit Tests
@@ -23,7 +24,7 @@ pull_request_rules:
 
   - name: Automatically approve and merge Dependabot PRs
     conditions:
-      - base=master
+      - base~=master|v1-node16
       - author=dependabot[bot]
       - status-success=Run Unit Tests
       - -title~=(WIP|wip)

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,6 @@ outputs:
   aws-account-id:
     description: 'The AWS account ID for the provided credentials'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
Issue #, if available: #489

Description of changes: Node 12 is EOL and we need to move to a more modern version. A comprehensive release is set for a new major version of this action which will use the most up to date version of node, but for now customers are getting warnings about Node 12 actions on GitHub. This is a temporary fix that will bump the runs to Node 16 while we work on v2.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.





