### PR TITLE
feat: GitHub-native release tagging

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -13,7 +13,7 @@ jobs:
         # These inputs are both required
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         message: |
-          ### ⚠️Comment Visibility Warning⚠️ 
+          ** Note **
           Comments on closed issues are hard for our team to see. 
           If you need more assistance, please either tag a team member or open a new issue that references this one.
           If you wish to keep having a conversation with other community members under this issue feel free to do so.

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,4 +1,4 @@
-name: Update dist files on 
+name: Update dist files on push branches
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ v1-node16 }}
+          ref: v1-node16
           token: ${{ env.OSDS_ACCESS_TOKEN }}
       - name: Push new merge commit
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Update release tags
+
+on:
+  workflow_dispatch:
+    inputs:
+      v1:
+        description: 'Update v1 release tag to the tip of the selected branch'
+        required: false
+        type: boolean
+      v1-versioned:
+        description: 'Push a new release semantic versioned tag to the selected branch'
+        required: false
+        type: boolean
+      v1-node16:
+        description: 'Merge the tip of the branch selected into v1-node16'
+        required: false
+        type: boolean
+
+jobs:
+  v1:
+    name: Update v1 release tag
+    if: ${{ v1 }}
+    timeout-minutes: 15
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.SECRETS_AWS_ROLE_TO_ASSUME }}
+          role-session-name: SecretsManagerFetch
+          role-duration-seconds: 900
+      - name: Get bot user token
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          parse-json-secrets: true
+          secret-ids: |
+            OSDS,arn:aws:secretsmanager:us-west-2:294535624312:secret:github-aws-sdk-osds-automation-ZHNalp
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+          token: ${{ env.OSDS_ACCESS_TOKEN }}
+      - name: Push tag
+        run: |
+          echo "::add-mask::${{ env.OSDS_ACCESS_TOKEN }}"
+          git config --global user.name "GitHub Actions"
+          git tag -f -a v1 -m "Update v1 to ${{ github.sha }}"
+          git push https://${{ env.OSDS_ACCESS_TOKEN }}@github.com/aws-actions/configure-aws-credentials.git -f --tags
+  v1-node16:
+    name: Merge the master into v1-node16
+    if: ${{ v1-node16 }}
+    timeout-minutes: 15
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.SECRETS_AWS_ROLE_TO_ASSUME }}
+          role-session-name: SecretsManagerFetch
+          role-duration-seconds: 900
+      - name: Get bot user token
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          parse-json-secrets: true
+          secret-ids: |
+            OSDS,arn:aws:secretsmanager:us-west-2:294535624312:secret:github-aws-sdk-osds-automation-ZHNalp
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ v1-node16 }}
+          token: ${{ env.OSDS_ACCESS_TOKEN }}
+      - name: Push new merge commit
+        run: |
+          echo "::add-mask::${{ env.OSDS_ACCESS_TOKEN }}"
+          git config --global user.name "GitHub Actions"
+          git merge ${{ github.ref_name }} -m 'Merge ${{ github.ref_name }} into v1-node16'
+          git push https://${{ env.OSDS_ACCESS_TOKEN }}@github.com/aws-actions/configure-aws-credentials.git
+  v1-versioned:
+    description: 'Push a new semantic version tag'
+    if: ${{ v1-versioned }}
+    timeout-minutes: 15
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.SECRETS_AWS_ROLE_TO_ASSUME }}
+          role-session-name: SecretsManagerFetch
+          role-duration-seconds: 900
+      - name: Get bot user token
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          parse-json-secrets: true
+          secret-ids: |
+            OSDS,arn:aws:secretsmanager:us-west-2:294535624312:secret:github-aws-sdk-osds-automation-ZHNalp
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+          token: ${{ env.OSDS_ACCESS_TOKEN }}
+      - name: Get new semantic version
+        id: semver
+        uses: paulhatch/semantic-version@v4.0.2
+        with:
+          tag_prefix: 'v'
+          major_pattern: '!'
+      - name: Push semantic tag
+        run: |
+          echo "::add-mask::${{ env.OSDS_ACCESS_TOKEN }}"
+          git config --global user.name "GitHub Actions"
+          git tag -f -a ${{ steps.semver.version_tag }} -m "New ${{ steps.semver.version_tag }} release"
+          git push https://${{ env.OSDS_ACCESS_TOKEN }}@github.com/aws-actions/configure-aws-credentials.git -f --tags


### PR DESCRIPTION
- chore: reword closed issue message
- chore: minor name edits to package action
- chore: add release tagging workflow
- fix: version v1-node16 issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
