### PR TITLE
fix: packaging test failure

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,6 +16,16 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+      - name: Package
+        run: |
+          npm ci
+          npm test
+          npm run package
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -29,17 +39,6 @@ jobs:
           parse-json-secrets: true
           secret-ids: |
             OSDS,arn:aws:secretsmanager:us-west-2:294535624312:secret:github-aws-sdk-osds-automation-ZHNalp
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.ref_name }}
-          token: ${{ env.OSDS_ACCESS_TOKEN }}
-      - name: Package
-        run: |
-          npm ci
-          npm test
-          npm run package
       - name: Commit
         run: |
           echo "::add-mask::${{ env.OSDS_ACCESS_TOKEN }}}"


### PR DESCRIPTION
The tests fail if there are credentials available in the env, so we need to get the AWS credentials *after* the package step.

---
