### PR TITLE
feat: allow-list option for aws account id

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ We recommend following [Amazon IAM best practices](https://docs.aws.amazon.com/I
 * [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) to the credentials used in GitHub Actions workflows.  Grant only the permissions required to perform the actions in your GitHub Actions workflows.
 * [Monitor the activity](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#keep-a-log) of the credentials used in GitHub Actions workflows.
 
+To prevent accidental deploys to the incorrect environment, you may define a comma-separated list of allowed account IDs to configure credentials for:
+
+```yaml
+- name: Configure AWS Credentials
+  uses: aws-actions/configure-aws-credentials@v1
+  with:
+    role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
+    aws-region: us-east-2
+    allowed-account-ids: 123456789100
+```
+
 ## Assuming a Role
 We recommend using [GitHub's OIDC provider](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) to get short-lived credentials needed for your actions. 
 Specifying `role-to-assume` **without** providing an `aws-access-key-id` or a `web-identity-token-file` will signal to the action that you wish to use the OIDC provider.

--- a/action.yml
+++ b/action.yml
@@ -55,8 +55,10 @@ inputs:
   role-skip-session-tagging:
     description: 'Skip session tagging during role assumption'
     required: false
-  http-proxy:
-    description: 'Proxy to use for the AWS SDK agent'
+  allowed-account-ids:
+    description: >-
+      Comma-separated list of allowed AWS account IDs to prevent accidental
+      deploys to the wrong environment.
     required: false
 outputs:
   aws-account-id:

--- a/index.test.js
+++ b/index.test.js
@@ -809,6 +809,37 @@ describe('Configure AWS Credentials', () => {
 
         await run();
     });
+    
+    test('denies accounts not defined in allow-account-ids', async () => {
+        process.env.SHOW_STACK_TRACE = 'false';
+
+        core.getInput = jest
+        .fn()
+        .mockImplementation(mockGetInput({ ...DEFAULT_INPUTS, 'allowed-account-ids': '000000000000' }));
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledWith(`Account ID of the provided credentials is not in 'allowed-account-ids'`);
+    });
+
+    test('allows accounts defined in allow-account-ids', async () => {
+        core.getInput = jest
+        .fn()
+        .mockImplementation(mockGetInput({ ...DEFAULT_INPUTS, 'allowed-account-ids': `${FAKE_ACCOUNT_ID}, 000000000000` }));
+
+        await run();
+    });
+
+    test('throws if account id list is invalid', async () => {
+        process.env.SHOW_STACK_TRACE = 'false';
+
+        // account id is too short
+        core.getInput = jest
+        .fn()
+        .mockImplementation(mockGetInput({ ...DEFAULT_INPUTS, 'allowed-account-ids': '0' }));
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledWith('Allowed account ID list is not valid, must be comma-separated list of 12-digit IDs');
+    })
 
     describe('proxy settings', () => {
 


### PR DESCRIPTION
*Issue #, if available:* 

* Closes #432

*Description of changes:*

Users may set the `allowed-account-ids` input variable to define a comma-separated list of accounts that may be authenticated against.

This input variable is checked against regex that ensures that all provided account IDs are 12 digits[^1] and are in a comma-separated list.

---

* [x] Have you followed the guidelines in our [Contributing 
guide?](https://github.com/aws-actions/configure-aws-credentials/blob/master/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[^1]: via https://docs.aws.amazon.com/organizations/latest/APIReference/API_Account.html
