### PR TITLE
retry when access keys have special chars

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,9 @@ inputs:
   http-proxy:
     description: 'Proxy to use for the AWS SDK agent'
     required: false
+  no-special-chars-in-access-keys:
+    description: 'Regenrate access keys if they contain special characters'
+    required: false
 outputs:
   aws-account-id:
     description: 'The AWS account ID for the provided credentials'

--- a/index.test.js
+++ b/index.test.js
@@ -678,7 +678,7 @@ describe('Configure AWS Credentials', () => {
         });
 
         await assert.rejects(() => run());
-        expect(mockStsAssumeRoleWithWebIdentity).toHaveBeenCalledTimes(12)
+        expect(mockStsAssumeRoleWithWebIdentity).toHaveBeenCalledTimes(25)
     });
 
     test('role external ID provided', async () => {


### PR DESCRIPTION
*Issue #, if available:* #599

*Description of changes:*
1) Added a boolean input "no-special-chars-in-access-keys"
2) If new input is set to true, we will retry assume role to regenerate the temporary credentials until they don't contain any special characters
2) Increased the default number of retries to 25 (to offset the fact that we cause more retries)
3) Set a maximum sleep time of 1 minute between retries (since it gets pretty long with 25 retries)

I have also been experimenting with regenerating the temp credentials only if the secret access key starts with a special character (since this is what I noticed every time I got a 403 error) and it seems to be working, with a lot less retries, so that is another option (and then there's no need to increase the max retries that much)
---

* [V] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/master/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
