### PR TITLE
Updated node version for action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,6 @@ outputs:
   aws-account-id:
     description: 'The AWS account ID for the provided credentials'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
Description

Updated the node version from 12 to 16, due to the deprecation of the github node12 actions.
For more Infos read the blog post provided by Github:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

---

*[x ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/master/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
