### PR TITLE
Remove assumptions about unhandled errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -379,7 +379,7 @@ async function run() {
     }
   }
   catch (error) {
-    core.setFailed(error.message);
+    core.setFailed(error);
 
     const showStackTrace = process.env.SHOW_STACK_TRACE;
 


### PR DESCRIPTION
*Issue #, if available:*
#395

*Description of changes:*
The main function in index.js has a broad try/catch that handles all unhandled errors thrown when the action runs. However, it makes an intermittently incorrect assumption that the error thrown has a `.message` property. When this is not true, the stack trace is not emitted, preventing the end user from discovering the reason for the exception.

This commit changes the error handling to pass the entire error object to @ actions/toolkit/core, which then calls `.toString()` on the argument, effectively maintaining behavior for actual Error objects.

This commit does not correct the underlying causes of such errors; it only surfaces them


---

* [SURETHING] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/master/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
