### PR TITLE
Implement role-output-credentials for v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,28 @@ In this example, the audience has been changed from the default to use a differe
 
 Changing the default audience may be necessary when using non-default [AWS partitions](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 
+```yaml
+    - name: Configure AWS Credentials
+      id: aws-credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: us-east-2
+        role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
+        role-session-name: MySessionName
+        role-output-credentials: true
+
+    - name: Get Caller Identity
+      env:
+        AWS_REGION: '${{ steps.aws-credentials.outputs.aws-region }}'
+        AWS_DEFAULT_REGION: '${{ steps.aws-credentials.outputs.aws-default-region }}'
+        AWS_ACCESS_KEY_ID: '${{ steps.aws-credentials.outputs.aws-access-key-id }}'
+        AWS_SECRET_ACCESS_KEY: '${{ steps.aws-credentials.aws.outputs.aws-secret-access-key }}'
+        AWS_SESSION_TOKEN: '${{ steps.aws-credentials.outputs.aws-session-token }}'
+      run: |
+        aws sts get-caller-identity
+```
+In this example, input `role-output-credentials` forces action to output assumed role's credentials without populating `GITHUB_ENV` environmental variable. Following steps can reference output of the action step to get credentials.
+
 ### Sample IAM Role CloudFormation Template
 ```yaml
 Parameters:

--- a/action.yml
+++ b/action.yml
@@ -55,9 +55,33 @@ inputs:
   role-skip-session-tagging:
     description: 'Skip session tagging during role assumption'
     required: false
+  role-output-credentials:
+    description: >-
+      Whether to output assumed credentials instead of exporting them to environment.
+      Valid values are 'true' and 'false'.
+      Defaults to false
+    required: false
+  http-proxy:
+    description: 'Proxy to use for the AWS SDK agent'
+    required: false
 outputs:
   aws-account-id:
     description: 'The AWS account ID for the provided credentials'
+  aws-default-region:
+    description: >-
+      The AWS default region name. This is output is available if `role-output-credentials` is set to true
+  aws-region:
+    description: >-
+      The AWS region name. This is output is available if `role-output-credentials` is set to true
+  aws-access-key-id:
+    description: >-
+      AWS Access Key ID of the assumed role. This is output is available if `role-output-credentials` is set to true
+  aws-secret-access-key:
+    description: >-
+      AWS Secret Access Key of the assumed role. This is output is available if `role-output-credentials` is set to true
+  aws-session-token:
+    description: >-
+      AWS Session Token. This is output is available if `role-output-credentials` is set to true
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/index.test.js
+++ b/index.test.js
@@ -428,6 +428,42 @@ describe('Configure AWS Credentials', () => {
         expect(core.setOutput).toHaveBeenNthCalledWith(2, 'aws-account-id', FAKE_ROLE_ACCOUNT_ID);
     });
 
+    test('basic role assumption with output credentials', async () => {
+        core.getInput = jest
+            .fn()
+            .mockImplementation(mockGetInput({...ASSUME_ROLE_INPUTS, 'role-output-credentials': 'TRUE'}));
+
+        await run();
+        expect(mockStsAssumeRole).toHaveBeenCalledTimes(1);
+        expect(core.exportVariable).toHaveBeenCalledTimes(0);
+        expect(core.setSecret).toHaveBeenCalledTimes(7);
+        expect(core.setOutput).toHaveBeenCalledTimes(9);
+
+        // first the source credentials are exported and masked
+        expect(core.setSecret).toHaveBeenNthCalledWith(1, FAKE_ACCESS_KEY_ID);
+        expect(core.setSecret).toHaveBeenNthCalledWith(2, FAKE_SECRET_ACCESS_KEY);
+        expect(core.setSecret).toHaveBeenNthCalledWith(3, FAKE_ACCOUNT_ID);
+
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'aws-default-region', FAKE_REGION);
+        expect(core.setOutput).toHaveBeenNthCalledWith(2, 'aws-region', FAKE_REGION);
+        expect(core.setOutput).toHaveBeenNthCalledWith(3, 'aws-access-key-id', FAKE_ACCESS_KEY_ID);
+        expect(core.setOutput).toHaveBeenNthCalledWith(4, 'aws-secret-access-key', FAKE_SECRET_ACCESS_KEY);
+
+        expect(core.setOutput).toHaveBeenNthCalledWith(5, 'aws-account-id', FAKE_ACCOUNT_ID);
+
+        // then the role credentials are exported and masked
+        expect(core.setSecret).toHaveBeenNthCalledWith(4, FAKE_STS_ACCESS_KEY_ID);
+        expect(core.setSecret).toHaveBeenNthCalledWith(5, FAKE_STS_SECRET_ACCESS_KEY);
+        expect(core.setSecret).toHaveBeenNthCalledWith(6, FAKE_STS_SESSION_TOKEN);
+        expect(core.setSecret).toHaveBeenNthCalledWith(7, FAKE_ROLE_ACCOUNT_ID);
+
+        expect(core.setOutput).toHaveBeenNthCalledWith(6, 'aws-access-key-id', FAKE_STS_ACCESS_KEY_ID);
+        expect(core.setOutput).toHaveBeenNthCalledWith(7, 'aws-secret-access-key', FAKE_STS_SECRET_ACCESS_KEY);
+        expect(core.setOutput).toHaveBeenNthCalledWith(8, 'aws-session-token', FAKE_STS_SESSION_TOKEN);
+        expect(core.setOutput).toHaveBeenNthCalledWith(9, 'aws-account-id', FAKE_ROLE_ACCOUNT_ID);
+
+    });
+
     test('assume role can pull source credentials from self-hosted environment', async () => {
         core.getInput = jest
             .fn()


### PR DESCRIPTION
*Issue #, if available:*
- #236 
- #379 

*Description of changes:*
A re-implementation of @blz-ea's role-output-credentials from #325 for the newer v1 aws-credentials provider.

Implements output-credentials functionality to support use-cases that do not wish to persist credentials into GHA environment variables (useful when multiple accounts or roles need to be involved).

Does NOT re-implement drop-current-credentials as I have no use-case for that.

I hope that by a smaller more tactile patch I can get this merged upstream.

All credit to @blz-ea, but direct admonitions at me.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
