### PR TITLE
Make aws-region optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
   aws-region:
     description: 'AWS Region, e.g. us-east-2'
-    required: true
+    required: false
   mask-aws-account-id:
     description: >-
       Whether to set the AWS account ID for these credentials as a secret value,
@@ -44,7 +44,7 @@ inputs:
       assume an IAM role using a web identity. E.g., from within an Amazon EKS worker node
     required: false
   role-duration-seconds:
-    description: "Role duration in seconds (default: 6 hours, 1 hour for OIDC/specified aws-session-token)"
+    description: 'Role duration in seconds (default: 6 hours, 1 hour for OIDC/specified aws-session-token)'
     required: false
   role-session-name:
     description: 'Role session name (default: GitHubActions)'

--- a/index.js
+++ b/index.js
@@ -287,7 +287,7 @@ async function run() {
     const accessKeyId = core.getInput('aws-access-key-id', { required: false });
     const audience = core.getInput('audience', { required: false });
     const secretAccessKey = core.getInput('aws-secret-access-key', { required: false });
-    const region = core.getInput('aws-region', { required: true });
+    const region = core.getInput('aws-region', { required: true }) || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
     const sessionToken = core.getInput('aws-session-token', { required: false });
     const maskAccountId = core.getInput('mask-aws-account-id', { required: false });
     const roleToAssume = core.getInput('role-to-assume', {required: false});

--- a/index.test.js
+++ b/index.test.js
@@ -341,6 +341,23 @@ describe('Configure AWS Credentials', () => {
         expect(core.setFailed).toHaveBeenCalledWith('Region is not valid: $AWS_REGION');
     });
 
+    test('aws-region should be optional and use AWS_REGION instead', async () => {
+        const mockInputs = { ...CREDS_INPUTS }
+        core.getInput = jest.fn().mockImplementation(mockGetInput(mockInputs))
+        process.env.AWS_REGION = "fake-region"
+        await run()
+        expect(core.exportVariable).toHaveBeenCalledWith("AWS_REGION", "fake-region")
+        expect(core.exportVariable).toHaveBeenCalledWith("AWS_DEFAULT_REGION", "fake-region")
+    })
+    test('aws-region should be optional and use AWS_DEFAULT_REGION if AWS_REGION is not available', async () => {
+        const mockInputs = { ...CREDS_INPUTS }
+        core.getInput = jest.fn().mockImplementation(mockGetInput(mockInputs))
+        process.env.AWS_DEFAULT_REGION = "fake-default-region"
+        await run()
+        expect(core.exportVariable).toHaveBeenCalledWith("AWS_REGION", "fake-default-region")
+        expect(core.exportVariable).toHaveBeenCalledWith("AWS_DEFAULT_REGION", "fake-default-region")
+    })
+
     test('throws error if access key id exists but missing secret access key', async () => {
         process.env.SHOW_STACK_TRACE = 'false';
         const inputsWIthoutSecretKey = {...ASSUME_ROLE_INPUTS}


### PR DESCRIPTION
*Issue #, if available:*
- Closes #305 
*Description of changes:*
Makes region optional and falls back to `AWS_REGION` and `AWS_DEFAULT_REGION` taken from this previous discussion
https://github.com/aws-actions/configure-aws-credentials/pull/431#discussion_r987473840
---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/master/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
