### PR TITLE
docs(readme): fix-typo-in-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ your repository's workflow files. The `v2` tag is a moving tag that will always
 apply to the lastest version 2 train release. We will also provide minor version
 tags on every release, and create a `v3` tag when we are ready for a new major
 release. If you had been following the development of this action so far, this
-is a change to previous states release policy.
+is a change to previous stated release policy.
 
 ### Table of Contents
 <!-- toc -->


### PR DESCRIPTION
Fixes a single typo in the README.

(`previous states ..` -> `previous stated release policy`)

*Issue #, if available:*

*Description of changes:*

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
