### PR TITLE
fix: restore ability to use web-identity-token-file (issue: #124)

### DIFF
--- a/index.js
+++ b/index.js
@@ -364,6 +364,9 @@ async function run() {
       webIdentityToken = await core.getIDToken(audience);
       roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || DEFAULT_ROLE_DURATION_FOR_OIDC_ROLES;
       // We don't validate the credentials here because we don't have them yet when using OIDC.
+    } else if (webIdentityTokenFile) {
+      roleDurationSeconds = core.getInput('role-duration-seconds', {required: false}) || DEFAULT_ROLE_DURATION_FOR_OIDC_ROLES;
+      // We don't validate the credentials here because we don't have them yet when using webIdentityTokenFile.      
     } else {
       // Regardless of whether any source credentials were provided as inputs,
       // validate that the SDK can actually pick up credentials.  This validates


### PR DESCRIPTION
*Issue #124*

*Description of changes:*

The validation logic for credentials was failing for the `web-identity-token-file` use case which needs to be handled similarly to the OIDC case as I understand it

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
