### PR TITLE
feat: Add Configurable `maxRetries`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,9 @@ inputs:
   managed-session-policies:
     description: 'List of managed session policies'
     required: false
+  max-retries:
+    description: 'Maximum retries (default: 12)'
+    required: false
 outputs:
   aws-account-id:
     description: 'The AWS account ID for the provided credentials'

--- a/index.test.js
+++ b/index.test.js
@@ -774,6 +774,27 @@ describe('Configure AWS Credentials', () => {
         expect(mockStsAssumeRoleWithWebIdentity).toHaveBeenCalledTimes(12)
     });
 
+    test('role assumption fails after configured maximum trials', async () => {
+        process.env.GITHUB_ACTIONS = 'true';
+        process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = 'test-token';
+
+        core.getInput = jest
+            .fn()
+            .mockImplementation(mockGetInput({
+              'role-to-assume': ROLE_ARN,
+              'aws-region': FAKE_REGION,
+              'max-retries': 1
+            }));
+
+        mockStsAssumeRoleWithWebIdentity.mockReset();
+        mockStsAssumeRoleWithWebIdentity.mockImplementation(() => {
+            throw new Error();
+        });
+
+        await assert.rejects(() => run());
+        expect(mockStsAssumeRoleWithWebIdentity).toHaveBeenCalledTimes(1)
+    });
+
     test('role external ID provided', async () => {
         core.getInput = jest
             .fn()


### PR DESCRIPTION
*Issue #, if available:* #683

*Description of changes:*
- Make the `maxRetries` parameter of `retryAndBackoff()` configurable with a new `max-retries` input.
- Set the default `max-retries` to 12 (the original value).
- Add test: `role assumption fails after configured maximum trials`

Configuring maximum retries is done as follows:
```yaml
- uses: aws-actions/configure-aws-credentials@v2
  with:
    ...
    max-retries: 1
```
---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
