### PR TITLE
fix: action fails when intending to use existing credentials

### DIFF
--- a/.github/workflows/tests-integ.yml
+++ b/.github/workflows/tests-integ.yml
@@ -48,6 +48,28 @@ jobs:
           role-to-assume: ${{ secrets.SECRETS_AWS_ROLE_TO_ASSUME }}
           role-session-name: IntegAccessKeysAssumeRole
           role-external-id: ${{ secrets.SECRETS_AWS_ROLE_EXTERNAL_ID }}
+  integ-access-keys-env:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [[self-hosted, linux-fargate], windows-latest, ubuntu-latest, macos-latest]
+        node: [14, 16, 18]
+    name: Run access key integ tests
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+      - name: Integ test for access keys
+        uses: ./
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.SECRETS_AWS_ROLE_TO_ASSUME }}
+          role-session-name: IntegAccessKeysAssumeRole
+          role-external-id: ${{ secrets.SECRETS_AWS_ROLE_EXTERNAL_ID }}
   integ-iam-user:
     strategy:
       fail-fast: false

--- a/.github/workflows/tests-integ.yml
+++ b/.github/workflows/tests-integ.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         os: [[self-hosted, linux-fargate], windows-latest, ubuntu-latest, macos-latest]
         node: [14, 16, 18]
-    name: Run access key integ tests
+    name: Run access key from env integ tests
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:

--- a/README.md
+++ b/README.md
@@ -161,13 +161,15 @@ We recommend using [GitHub's OIDC provider](https://docs.github.com/en/actions/d
 
 The following table describes which method is used based on which values are supplied to the Action:
 
-| **Identity Used**                                               | `aws-access-key-id` | `role-to-assume` | `web-identity-token-file` | `role-chaining` |
-| --------------------------------------------------------------- | ------------------- | ---------------- | ------------------------- | - |
-| [✅ Recommended] Assume Role directly using GitHub OIDC provider |                     | ✔                |                           | |
-| IAM User                                                        | ✔                   |                  |                           | |
-| Assume Role using IAM User credentials                          | ✔                   | ✔                |                           | |
-| Assume Role using WebIdentity Token File credentials            |                     | ✔                | ✔                         | |
-| Assume Role using existing credentials | | ✔ | | ✔ |
+| **Identity Used**                                               | `aws-access-key-id` | `role-to-assume` | `web-identity-token-file` | `role-chaining` | `id-token` permission
+| --------------------------------------------------------------- | ------------------- | ---------------- | ------------------------- | - | - |
+| [✅ Recommended] Assume Role directly using GitHub OIDC provider |                     | ✔                |                           | | ✔ |
+| IAM User                                                        | ✔                   |                  |                           | | |
+| Assume Role using IAM User credentials                          | ✔                   | ✔                |                           | | |
+| Assume Role using WebIdentity Token File credentials            |                     | ✔                | ✔                         | | |
+| Assume Role using existing credentials | | ✔ | | ✔ | |
+
+* Existing credentials in your runner 
 
 ### Credential Lifetime
 The default session duration is **1 hour**.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The following table describes which method is used based on which values are sup
 | Assume Role using WebIdentity Token File credentials            |                     | ✔                | ✔                         | | |
 | Assume Role using existing credentials | | ✔ | | ✔ | |
 
-* Existing credentials in your runner 
+*Note: `role-chaining` is not necessary to use existing credentials in every use case. If you're getting a "Credentials loaded by the SDK do not match" error, try enabling this prop.
 
 ### Credential Lifetime
 The default session duration is **1 hour**.

--- a/dist/index.js
+++ b/dist/index.js
@@ -511,7 +511,9 @@ async function run() {
             // in any error messages.
             (0, helpers_1.exportCredentials)({ AccessKeyId, SecretAccessKey, SessionToken });
         }
-        else if (!webIdentityTokenFile && !roleChaining) {
+        else if (!webIdentityTokenFile &&
+            !roleChaining &&
+            !(process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {
             throw new Error('Could not determine how to assume credentials. Please check your inputs and try again.');
         }
         if (AccessKeyId || roleChaining || (process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -469,7 +469,8 @@ async function run() {
                 !AccessKeyId &&
                 !process.env['ACTIONS_ID_TOKEN_REQUEST_TOKEN'] &&
                 !roleChaining) {
-                core.info('It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission?');
+                core.info('It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? ' +
+                    'If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.');
             }
             return (!!roleToAssume &&
                 !!process.env['ACTIONS_ID_TOKEN_REQUEST_TOKEN'] &&
@@ -513,7 +514,7 @@ async function run() {
         else if (!webIdentityTokenFile && !roleChaining) {
             throw new Error('Could not determine how to assume credentials. Please check your inputs and try again.');
         }
-        if (AccessKeyId || roleChaining) {
+        if (AccessKeyId || roleChaining || (process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {
             // Validate that the SDK can actually pick up credentials.
             // This validates cases where this action is using existing environment credentials,
             // and cases where the user intended to provide input credentials but the secrets inputs resolved to empty strings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,8 @@ export async function run() {
         !roleChaining
       ) {
         core.info(
-          'It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission?'
+          'It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? ' +
+            'If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.'
         );
       }
       return (
@@ -119,7 +120,7 @@ export async function run() {
       throw new Error('Could not determine how to assume credentials. Please check your inputs and try again.');
     }
 
-    if (AccessKeyId || roleChaining) {
+    if (AccessKeyId || roleChaining || (process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {
       // Validate that the SDK can actually pick up credentials.
       // This validates cases where this action is using existing environment credentials,
       // and cases where the user intended to provide input credentials but the secrets inputs resolved to empty strings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,11 @@ export async function run() {
       // the source credentials to already be masked as secrets
       // in any error messages.
       exportCredentials({ AccessKeyId, SecretAccessKey, SessionToken });
-    } else if (!webIdentityTokenFile && !roleChaining) {
+    } else if (
+      !webIdentityTokenFile &&
+      !roleChaining &&
+      !(process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])
+    ) {
       throw new Error('Could not determine how to assume credentials. Please check your inputs and try again.');
     }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -519,7 +519,8 @@ describe('Configure AWS Credentials', () => {
     await run();
 
     expect(core.info).toHaveBeenCalledWith(
-      'It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission?'
+      'It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission?' +
+        ' If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.'
     );
     expect(core.setFailed).toHaveBeenCalledWith(
       'Could not determine how to assume credentials. Please check your inputs and try again.'

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -527,6 +527,25 @@ describe('Configure AWS Credentials', () => {
     );
   });
 
+  test('Assume role with existing credentials if nothing else set', async () => {
+    process.env['AWS_ACCESS_KEY_ID'] = FAKE_ACCESS_KEY_ID;
+    process.env['AWS_SECRET_ACCESS_KEY'] = FAKE_SECRET_ACCESS_KEY;
+    jest.spyOn(core, 'getInput').mockImplementation(
+      mockGetInput({
+        'role-to-assume': ROLE_ARN,
+        'aws-region': FAKE_REGION,
+      })
+    );
+
+    await run();
+
+    expect(core.info).toHaveBeenCalledWith(
+      'It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission?' +
+        ' If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.'
+    );
+    expect(mockedSTS.commandCalls(AssumeRoleCommand).length).toEqual(1);
+  });
+
   test('role assumption fails after maximum trials using OIDC provider', async () => {
     process.env['GITHUB_ACTIONS'] = 'true';
     process.env['ACTIONS_ID_TOKEN_REQUEST_TOKEN'] = 'test-token';


### PR DESCRIPTION
fixes: #792 

If this configuration is used, a message will print in your workflow checking if you want to use OIDC. You can safely ignore this message

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
