### PR TITLE
chore: change sts.amazon.com to sts.amazonaws.com in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ We recommend using [GitHub's OIDC provider](https://docs.github.com/en/actions/d
 
 ### Audience
 
-When the JWT is created, an audience needs to be specified. By default, the audience is `sts.amazon.com` and this will work for most cases. Changing the default audience may be necessary when using non-default AWS partitions. You can specify the audience through the `audience` input:
+When the JWT is created, an audience needs to be specified. By default, the audience is `sts.amazonaws.com` and this will work for most cases. Changing the default audience may be necessary when using non-default AWS partitions. You can specify the audience through the `audience` input:
 
 ```yaml
     - name: Configure AWS Credentials for China region audience


### PR DESCRIPTION
Small typo that caused a major headache

*Issue #, if available:* Incorrect audience in readme

*Description of changes:* Corrects the audience displayed in readme

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
