### PR TITLE
fix: validation logic throwing unwanted errors

### DIFF
--- a/.github/workflows/tests-integ.yml
+++ b/.github/workflows/tests-integ.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run Integ tests
 
 on:
   workflow_dispatch:
@@ -15,6 +15,33 @@ jobs:
         node: [14, 16, 18]
     name: Run OIDC integ tests
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+      - name: Integ test for OIDC
+        uses: ./
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.SECRETS_OIDC_AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
+          role-session-name: IntegOidcAssumeRole
+          role-external-id: ${{ secrets.SECRETS_OIDC_AWS_ROLE_EXTERNAL_ID }}
+  integ-oidc-env:
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [[self-hosted, linux-fargate], windows-latest, ubuntu-latest, macos-latest]
+        node: [14, 16, 18]
+    name: Run OIDC integ tests with existing invalid env vars
+    runs-on: ${{ matrix.os }}
+    env:
+      AWS_ACCESS_KEY_ID: dummyaccesskeyid
+      AWS_SECRET_ACCESS_KEY: dummysecretkey
+      AWS_SESSION_TOKEN: dummytoken
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"

--- a/dist/index.js
+++ b/dist/index.js
@@ -523,7 +523,9 @@ async function run() {
         else if (!webIdentityTokenFile &&
             !roleChaining &&
             !(process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {
-            throw new Error('Could not determine how to assume credentials. Please check your inputs and try again.');
+            // Proceed if credentials are picked up
+            await credentialsClient.validateCredentials();
+            sourceAccountId = await (0, helpers_1.exportAccountId)(credentialsClient, maskAccountId);
         }
         if (AccessKeyId || roleChaining || (process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {
             // Validate that the SDK can actually pick up credentials.

--- a/dist/index.js
+++ b/dist/index.js
@@ -520,14 +520,12 @@ async function run() {
             // in any error messages.
             (0, helpers_1.exportCredentials)({ AccessKeyId, SecretAccessKey, SessionToken });
         }
-        else if (!webIdentityTokenFile &&
-            !roleChaining &&
-            !(process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {
-            // Proceed if credentials are picked up
+        else if (!webIdentityTokenFile && !roleChaining) {
+            // Proceed only if credentials can be picked up
             await credentialsClient.validateCredentials();
             sourceAccountId = await (0, helpers_1.exportAccountId)(credentialsClient, maskAccountId);
         }
-        if (AccessKeyId || roleChaining || (process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {
+        if (AccessKeyId || roleChaining) {
             // Validate that the SDK can actually pick up credentials.
             // This validates cases where this action is using existing environment credentials,
             // and cases where the user intended to provide input credentials but the secrets inputs resolved to empty strings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,17 +128,13 @@ export async function run() {
       // the source credentials to already be masked as secrets
       // in any error messages.
       exportCredentials({ AccessKeyId, SecretAccessKey, SessionToken });
-    } else if (
-      !webIdentityTokenFile &&
-      !roleChaining &&
-      !(process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])
-    ) {
-      // Proceed if credentials are picked up
+    } else if (!webIdentityTokenFile && !roleChaining) {
+      // Proceed only if credentials can be picked up
       await credentialsClient.validateCredentials();
       sourceAccountId = await exportAccountId(credentialsClient, maskAccountId);
     }
 
-    if (AccessKeyId || roleChaining || (process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {
+    if (AccessKeyId || roleChaining) {
       // Validate that the SDK can actually pick up credentials.
       // This validates cases where this action is using existing environment credentials,
       // and cases where the user intended to provide input credentials but the secrets inputs resolved to empty strings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,9 @@ export async function run() {
       !roleChaining &&
       !(process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])
     ) {
-      throw new Error('Could not determine how to assume credentials. Please check your inputs and try again.');
+      // Proceed if credentials are picked up
+      await credentialsClient.validateCredentials();
+      sourceAccountId = await exportAccountId(credentialsClient, maskAccountId);
     }
 
     if (AccessKeyId || roleChaining || (process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY'])) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -202,7 +202,7 @@ describe('Configure AWS Credentials', () => {
     await run();
 
     expect(core.setFailed).toHaveBeenCalledWith(
-      'Could not determine how to assume credentials. Please check your inputs and try again.'
+      'Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers'
     );
   });
 
@@ -217,7 +217,7 @@ describe('Configure AWS Credentials', () => {
     await run();
 
     expect(core.setFailed).toHaveBeenCalledWith(
-      'Could not determine how to assume credentials. Please check your inputs and try again.'
+      'Credentials could not be loaded, please check your action inputs: Access key ID empty after loading credentials'
     );
   });
 
@@ -508,6 +508,7 @@ describe('Configure AWS Credentials', () => {
   });
 
   test('GH OIDC check fails if token is not set', async () => {
+    (fromEnv as jest.Mock).mockReset();
     process.env['ACTIONS_ID_TOKEN_REQUEST_TOKEN'] = undefined;
     process.env['GITHUB_ACTIONS'] = 'true';
     jest.spyOn(core, 'getInput').mockImplementation(
@@ -524,7 +525,7 @@ describe('Configure AWS Credentials', () => {
         ' If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.'
     );
     expect(core.setFailed).toHaveBeenCalledWith(
-      'Could not determine how to assume credentials. Please check your inputs and try again.'
+      'Credentials could not be loaded, please check your action inputs: provider is not a function'
     );
   });
 


### PR DESCRIPTION
fixes: #817 fixes: #819

If we aren't sure what the user is trying to do, validate credentials and export account ID anyway. The check in place was too strict and didn't consider cases like instance roles

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
