### PR TITLE
chore: Update example ARN of China Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ You can specify the audience through the `audience` input:
       with:
         audience: sts.amazonaws.com.cn
         aws-region: us-east-3
-        role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
+        role-to-assume: arn:aws-cn:iam::123456789100:role/my-github-actions-role
 ```
 
 ### Configuring IAM to trust GitHub


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* In the example of using for AWS China the Role's ARN should also reflect the China partition.

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
