### PR TITLE
feat: Add MFA serial and token support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,12 @@ inputs:
   aws-session-token:
     description: AWS Session Token.
     required: false
+  mfa-token:
+    description: Token when the user/role requires MFA.
+    required: false
+  mfa-serial:
+    description: Serial/ARN when the user/role requires MFA.
+    required: false
   web-identity-token-file:
     description: Use the web identity token file from the provided file system path in order to assume an IAM role using a web identity, e.g. from within an Amazon EKS worker node.
     required: false

--- a/dist/cleanup/src/assumeRole.d.ts
+++ b/dist/cleanup/src/assumeRole.d.ts
@@ -9,6 +9,8 @@ export interface assumeRoleParams {
     roleExternalId?: string;
     webIdentityTokenFile?: string;
     webIdentityToken?: string;
+    mfaSerial?: string;
+    mfaToken?: string;
     inlineSessionPolicy?: string;
     managedSessionPolicies?: any[];
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -152,7 +152,7 @@ async function assumeRoleWithCredentials(params, client) {
     }
 }
 async function assumeRole(params) {
-    const { credentialsClient, sourceAccountId, roleToAssume, roleExternalId, roleDuration, roleSessionName, roleSkipSessionTagging, webIdentityTokenFile, webIdentityToken, inlineSessionPolicy, managedSessionPolicies, } = { ...params };
+    const { credentialsClient, sourceAccountId, roleToAssume, roleExternalId, roleDuration, roleSessionName, roleSkipSessionTagging, webIdentityTokenFile, webIdentityToken, mfaSerial, mfaToken, inlineSessionPolicy, managedSessionPolicies, } = { ...params };
     // Load GitHub environment variables
     const { GITHUB_REPOSITORY, GITHUB_WORKFLOW, GITHUB_ACTION, GITHUB_ACTOR, GITHUB_SHA, GITHUB_WORKSPACE } = process.env;
     if (!GITHUB_REPOSITORY || !GITHUB_WORKFLOW || !GITHUB_ACTION || !GITHUB_ACTOR || !GITHUB_SHA || !GITHUB_WORKSPACE) {
@@ -192,6 +192,8 @@ async function assumeRole(params) {
         ExternalId: roleExternalId ? roleExternalId : undefined,
         Policy: inlineSessionPolicy ? inlineSessionPolicy : undefined,
         PolicyArns: managedSessionPolicies?.length ? managedSessionPolicies : undefined,
+        SerialNumber: mfaSerial,
+        TokenCode: mfaToken,
     };
     const keys = Object.keys(commonAssumeRoleParams);
     keys.forEach((k) => commonAssumeRoleParams[k] === undefined && delete commonAssumeRoleParams[k]);
@@ -431,6 +433,8 @@ async function run() {
         const maskAccountId = maskAccountIdInput.toLowerCase() === 'true';
         const roleExternalId = core.getInput('role-external-id', { required: false });
         const webIdentityTokenFile = core.getInput('web-identity-token-file', { required: false });
+        const mfaSerial = core.getInput('mfa-serial', { required: false });
+        const mfaToken = core.getInput('mfa-token', { required: false });
         const roleDuration = parseInt(core.getInput('role-duration-seconds', { required: false })) || DEFAULT_ROLE_DURATION;
         const roleSessionName = core.getInput('role-session-name', { required: false }) || ROLE_SESSION_NAME;
         const roleSkipSessionTaggingInput = core.getInput('role-skip-session-tagging', { required: false }) || 'false';
@@ -544,6 +548,8 @@ async function run() {
                         roleSkipSessionTagging,
                         webIdentityTokenFile,
                         webIdentityToken,
+                        mfaSerial,
+                        mfaToken,
                         inlineSessionPolicy,
                         managedSessionPolicies,
                     });

--- a/src/assumeRole.ts
+++ b/src/assumeRole.ts
@@ -74,6 +74,8 @@ export interface assumeRoleParams {
   roleExternalId?: string;
   webIdentityTokenFile?: string;
   webIdentityToken?: string;
+  mfaSerial?: string;
+  mfaToken?: string;
   inlineSessionPolicy?: string;
   managedSessionPolicies?: any[];
 }
@@ -89,6 +91,8 @@ export async function assumeRole(params: assumeRoleParams) {
     roleSkipSessionTagging,
     webIdentityTokenFile,
     webIdentityToken,
+    mfaSerial,
+    mfaToken,
     inlineSessionPolicy,
     managedSessionPolicies,
   } = { ...params };
@@ -137,6 +141,8 @@ export async function assumeRole(params: assumeRoleParams) {
     ExternalId: roleExternalId ? roleExternalId : undefined,
     Policy: inlineSessionPolicy ? inlineSessionPolicy : undefined,
     PolicyArns: managedSessionPolicies?.length ? managedSessionPolicies : undefined,
+    SerialNumber: mfaSerial,
+    TokenCode: mfaToken,
   };
   const keys = Object.keys(commonAssumeRoleParams) as Array<keyof typeof commonAssumeRoleParams>;
   keys.forEach((k) => commonAssumeRoleParams[k] === undefined && delete commonAssumeRoleParams[k]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export async function run() {
     const maskAccountId = maskAccountIdInput.toLowerCase() === 'true';
     const roleExternalId = core.getInput('role-external-id', { required: false });
     const webIdentityTokenFile = core.getInput('web-identity-token-file', { required: false });
+    const mfaSerial = core.getInput('mfa-serial', { required: false });
+    const mfaToken = core.getInput('mfa-token', { required: false });
     const roleDuration = parseInt(core.getInput('role-duration-seconds', { required: false })) || DEFAULT_ROLE_DURATION;
     const roleSessionName = core.getInput('role-session-name', { required: false }) || ROLE_SESSION_NAME;
     const roleSkipSessionTaggingInput = core.getInput('role-skip-session-tagging', { required: false }) || 'false';
@@ -159,6 +161,8 @@ export async function run() {
               roleSkipSessionTagging,
               webIdentityTokenFile,
               webIdentityToken,
+              mfaSerial,
+              mfaToken,
               inlineSessionPolicy,
               managedSessionPolicies,
             });


### PR DESCRIPTION
Resolves issue https://github.com/aws-actions/configure-aws-credentials/issues/184

*Add an optional MFA device serial number and one-time token to the workflow inputs.*

This PR has been tested with a role that requires MFA and thus run with a real-world serial number and tokens.

---

* [✅] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
