### PR TITLE
chore(deps): update github actions versions

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v5
+    - uses: aws-actions/stale-issue-cleanup@v6
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,7 +35,7 @@ jobs:
           role-duration-seconds: 900
           role-session-name: SecretsManagerFetch
       - name: Get bot user token
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           parse-json-secrets: true
           secret-ids: |

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: amannn/action-semantic-pull-request@v4.5.0
+      - uses: amannn/action-semantic-pull-request@v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tests-integ.yml
+++ b/.github/workflows/tests-integ.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Integ test for OIDC
         uses: ./
         with:
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Integ test for OIDC
         uses: ./
         with:
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Integ test for access keys
         uses: ./
         with:
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Integ test for access keys
         uses: ./
         env:
@@ -103,7 +103,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Integ test for IAM user
         uses: ./
         with:

--- a/examples/cfn-deploy-example/.github/workflows/compliance.yml
+++ b/examples/cfn-deploy-example/.github/workflows/compliance.yml
@@ -6,7 +6,7 @@ jobs:
   sast-guard:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: grolston/guard-action@main
       with:
         data_directory: './cloudformation/' ## change to your template directory

--- a/examples/cfn-deploy-example/.github/workflows/deploy.yml
+++ b/examples/cfn-deploy-example/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -27,7 +27,7 @@ jobs:
         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
         role-session-name: myGitHubActions
     - name: Deploy EC2 Bastion
-      uses: aws-actions/aws-cloudformation-github-deploy@v1.0.3
+      uses: aws-actions/aws-cloudformation-github-deploy@v1.3.0
       with:
         name: myEC2bastion
         ## change to path to template in your github repo


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated GitHub actions versions (e.g. `actions/checkout@v3` -> `actions/checkout@v4`). I checked and it seemed like there were no breaking changes. However, I was not able to actually run the updated workflows.

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
