### PR TITLE
feat: Add ARN output and masking option in exportAccountId function

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
   mask-aws-account-id:
     description: Whether to mask the AWS account ID for these credentials as a secret value. By default the account ID will not be masked
     required: false
+  mask-arn:
+    description: Whether to mask the Amazon Resource Name (ARN) for these credentials as a secret value. By default the Amazon Resource Name (ARN) will not be masked
+    required: false
   role-duration-seconds:
     description: Role duration in seconds. Default is one hour.
     required: false

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -47665,17 +47665,31 @@ function exportRegion(region) {
     core.exportVariable('AWS_REGION', region);
 }
 // Obtains account ID from STS Client and sets it as output
-async function exportAccountId(credentialsClient, maskAccountId) {
+async function exportAccountId(credentialsClient, maskAccountId, maskArn) {
     const client = credentialsClient.stsClient;
     const identity = await client.send(new client_sts_1.GetCallerIdentityCommand({}));
     const accountId = identity.Account;
+    const arn = identity.Arn;
     if (!accountId) {
         throw new Error('Could not get Account ID from STS. Did you set credentials?');
     }
     if (maskAccountId) {
         core.setSecret(accountId);
     }
+    else {
+        core.info(`Authenticated as accountId ${accountId}`);
+    }
+    if (!arn) {
+        throw new Error('Could not get Amazon Resource Name (ARN) from STS. Did you set credentials?');
+    }
+    if (maskArn) {
+        core.setSecret(arn);
+    }
+    else {
+        core.info(`Authenticated as arn ${arn}`);
+    }
     core.setOutput('aws-account-id', accountId);
+    core.setOutput('arn', arn);
     return accountId;
 }
 // Tags have a more restrictive set of acceptable characters than GitHub environment variables can.

--- a/dist/cleanup/src/helpers.d.ts
+++ b/dist/cleanup/src/helpers.d.ts
@@ -3,7 +3,7 @@ import type { CredentialsClient } from './CredentialsClient';
 export declare function exportCredentials(creds?: Partial<Credentials>, outputCredentials?: boolean): void;
 export declare function unsetCredentials(): void;
 export declare function exportRegion(region: string): void;
-export declare function exportAccountId(credentialsClient: CredentialsClient, maskAccountId?: boolean): Promise<string>;
+export declare function exportAccountId(credentialsClient: CredentialsClient, maskAccountId?: boolean, maskArn?: boolean): Promise<string>;
 export declare function sanitizeGitHubVariables(name: string): string;
 export declare function defaultSleep(ms: number): Promise<unknown>;
 declare let sleep: typeof defaultSleep;

--- a/dist/index.js
+++ b/dist/index.js
@@ -301,17 +301,31 @@ function exportRegion(region) {
     core.exportVariable('AWS_REGION', region);
 }
 // Obtains account ID from STS Client and sets it as output
-async function exportAccountId(credentialsClient, maskAccountId) {
+async function exportAccountId(credentialsClient, maskAccountId, maskArn) {
     const client = credentialsClient.stsClient;
     const identity = await client.send(new client_sts_1.GetCallerIdentityCommand({}));
     const accountId = identity.Account;
+    const arn = identity.Arn;
     if (!accountId) {
         throw new Error('Could not get Account ID from STS. Did you set credentials?');
     }
     if (maskAccountId) {
         core.setSecret(accountId);
     }
+    else {
+        core.info(`Authenticated as accountId ${accountId}`);
+    }
+    if (!arn) {
+        throw new Error('Could not get Amazon Resource Name (ARN) from STS. Did you set credentials?');
+    }
+    if (maskArn) {
+        core.setSecret(arn);
+    }
+    else {
+        core.info(`Authenticated as arn ${arn}`);
+    }
     core.setOutput('aws-account-id', accountId);
+    core.setOutput('arn', arn);
     return accountId;
 }
 // Tags have a more restrictive set of acceptable characters than GitHub environment variables can.
@@ -429,6 +443,8 @@ async function run() {
         const audience = core.getInput('audience', { required: false });
         const maskAccountIdInput = core.getInput('mask-aws-account-id', { required: false }) || 'false';
         const maskAccountId = maskAccountIdInput.toLowerCase() === 'true';
+        const maskArnInput = core.getInput('mask-arn', { required: false }) || 'false';
+        const maskArn = maskArnInput.toLowerCase() === 'true';
         const roleExternalId = core.getInput('role-external-id', { required: false });
         const webIdentityTokenFile = core.getInput('web-identity-token-file', { required: false });
         const roleDuration = parseInt(core.getInput('role-duration-seconds', { required: false })) || DEFAULT_ROLE_DURATION;
@@ -519,14 +535,14 @@ async function run() {
         else if (!webIdentityTokenFile && !roleChaining) {
             // Proceed only if credentials can be picked up
             await credentialsClient.validateCredentials();
-            sourceAccountId = await (0, helpers_1.exportAccountId)(credentialsClient, maskAccountId);
+            sourceAccountId = await (0, helpers_1.exportAccountId)(credentialsClient, maskAccountId, maskArn);
         }
         if (AccessKeyId || roleChaining) {
             // Validate that the SDK can actually pick up credentials.
             // This validates cases where this action is using existing environment credentials,
             // and cases where the user intended to provide input credentials but the secrets inputs resolved to empty strings.
             await credentialsClient.validateCredentials(AccessKeyId, roleChaining);
-            sourceAccountId = await (0, helpers_1.exportAccountId)(credentialsClient, maskAccountId);
+            sourceAccountId = await (0, helpers_1.exportAccountId)(credentialsClient, maskAccountId, maskArn);
         }
         // Get role credentials if configured to do so
         if (roleToAssume) {
@@ -559,7 +575,7 @@ async function run() {
             if (!process.env['GITHUB_ACTIONS'] || AccessKeyId) {
                 await credentialsClient.validateCredentials(roleCredentials.Credentials?.AccessKeyId);
             }
-            await (0, helpers_1.exportAccountId)(credentialsClient, maskAccountId);
+            await (0, helpers_1.exportAccountId)(credentialsClient, maskAccountId, maskArn);
         }
         else {
             core.info('Proceeding with IAM user credentials');

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -55,17 +55,33 @@ export function exportRegion(region: string) {
 }
 
 // Obtains account ID from STS Client and sets it as output
-export async function exportAccountId(credentialsClient: CredentialsClient, maskAccountId?: boolean) {
+export async function exportAccountId(
+  credentialsClient: CredentialsClient,
+  maskAccountId?: boolean,
+  maskArn?: boolean
+) {
   const client = credentialsClient.stsClient;
   const identity = await client.send(new GetCallerIdentityCommand({}));
   const accountId = identity.Account;
+  const arn = identity.Arn;
   if (!accountId) {
     throw new Error('Could not get Account ID from STS. Did you set credentials?');
   }
   if (maskAccountId) {
     core.setSecret(accountId);
+  } else {
+    core.info(`Authenticated as accountId ${accountId}`);
+  }
+  if (!arn) {
+    throw new Error('Could not get Amazon Resource Name (ARN) from STS. Did you set credentials?');
+  }
+  if (maskArn) {
+    core.setSecret(arn);
+  } else {
+    core.info(`Authenticated as arn ${arn}`);
   }
   core.setOutput('aws-account-id', accountId);
+  core.setOutput('arn', arn);
   return accountId;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

#1062 

*Description of changes:*

Currently, only accountId is provided as an output. This update adds arn as an additional output and logs it for reference. For consistency, accountId is also logged.

To address privacy and security implications, a mask-arn option has been added. The default is set to false; when true, the ARN is masked and excluded from logs. The accountId follows similar behavior.

Additionally, test code has been added to cover these changes.

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
