### PR TITLE
fix: automerge action syntax

### DIFF
--- a/.github/workflows/automerge-approved-prs.yml
+++ b/.github/workflows/automerge-approved-prs.yml
@@ -9,10 +9,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    if: >-
-      github.event.review.state == 'approved' &&
-      github.event.repository == 'aws/configure-aws-credentials' &&
-      (github.event.review.author_association == 'OWNER' || github.event.review.user.login == 'aws-sdk-osds')
+    if: ${{ github.event.review.state == 'approved' && github.repository == 'aws/configure-aws-credentials' && (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.user.login == 'aws-sdk-osds') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The automerge-approved-prs workflow was getting skipped. I corrected a few syntax errors, and now it *should* work.
---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
