### PR TITLE
feat: idempotent fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ See [action.yml](./action.yml) for more detail.
 | disable-retry             | Disabled retry/backoff logic for assume role calls. By default, retries are enabled.              |    No    |
 | retry-max-attempts        | Limits the number of retry attempts before giving up. Defaults to 12.                             |    No    |
 | special-characters-workaround | Uncommonly, some environments cannot tolerate special characters in a secret key. This option will retry fetching credentials until the secret access key does not contain special characters. This option overrides disable-retry and retry-max-attempts. | No |
+| use-existing-credentials  | When set, the action will attempt to use existing credentials instead of fetching new credentials. Defaults to false. | No |
 
 #### Credential Lifetime
 The default session duration is **1 hour**.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See [action.yml](./action.yml) for more detail.
 | disable-retry             | Disabled retry/backoff logic for assume role calls. By default, retries are enabled.              |    No    |
 | retry-max-attempts        | Limits the number of retry attempts before giving up. Defaults to 12.                             |    No    |
 | special-characters-workaround | Uncommonly, some environments cannot tolerate special characters in a secret key. This option will retry fetching credentials until the secret access key does not contain special characters. This option overrides disable-retry and retry-max-attempts. | No |
-| use-existing-credentials  | When set, the action will attempt to use existing credentials instead of fetching new credentials. Defaults to false. | No |
+| use-existing-credentials  | When set, the action will check if existing credentials are valid and exit if they are. Defaults to false. |    No    |
 
 #### Credential Lifetime
 The default session duration is **1 hour**.

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ inputs:
     description: Some environments do not support special characters in AWS_SECRET_ACCESS_KEY. This option will retry fetching credentials until the secret access key does not contain special characters. This option overrides disable-retry and retry-max-attempts. This option is disabled by default
     required: false
   use-existing-credentials:
-    description: Set to true if you are using multiple workflows that use the same AWS Credentials. When enabled, this option will check if there are already valid credentials in the environment. If there are, new credentials will not be fetched. If there are not, the action will run as normal.
+    description: When enabled, this option will check if there are already valid credentials in the environment. If there are, new credentials will not be fetched. If there are not, the action will run as normal.
 outputs:
   aws-account-id:
     description: The AWS account ID for the provided credentials

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,8 @@ inputs:
   special-characters-workaround:
     description: Some environments do not support special characters in AWS_SECRET_ACCESS_KEY. This option will retry fetching credentials until the secret access key does not contain special characters. This option overrides disable-retry and retry-max-attempts. This option is disabled by default
     required: false
+  use-existing-credentials:
+    description: Set to true if you are using multiple workflows that use the same AWS Credentials. When enabled, this option will check if there are already valid credentials in the environment. If there are, new credentials will not be fetched. If there are not, the action will run as normal.
 outputs:
   aws-account-id:
     description: The AWS account ID for the provided credentials

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -144,3 +144,13 @@ export function isDefined<T>(i: T | undefined | null): i is T {
   return i !== undefined && i !== null;
 }
 /* c8 ignore stop */
+
+export async function areCredentialsValid(credentialsClient: CredentialsClient) {
+  const client = credentialsClient.stsClient;
+  const identity = await client.send(new GetCallerIdentityCommand({}));
+  const accountId = identity.Account;
+  if (!accountId) {
+    return false;
+  }
+  return true;
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -147,10 +147,13 @@ export function isDefined<T>(i: T | undefined | null): i is T {
 
 export async function areCredentialsValid(credentialsClient: CredentialsClient) {
   const client = credentialsClient.stsClient;
-  const identity = await client.send(new GetCallerIdentityCommand({}));
-  const accountId = identity.Account;
-  if (!accountId) {
+  try {
+    const identity = await client.send(new GetCallerIdentityCommand({}));
+    if (identity.Account) {
+      return true;
+    }
+    return false;
+  } catch (_) {
     return false;
   }
-  return true;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,8 @@ export async function run() {
     const specialCharacterWorkaroundInput =
       core.getInput('special-characters-workaround', { required: false }) || 'false';
     const specialCharacterWorkaround = specialCharacterWorkaroundInput.toLowerCase() === 'true';
-    const useExistingCredentials = core.getInput('use-existing-credentials', { required: false }) || 'false';
+    const useExistingCredentialsInput = core.getInput('use-existing-credentials', { required: false }) || 'false';
+    const useExistingCredentials = useExistingCredentialsInput.toLowerCase() === 'true';
     let maxRetries = Number.parseInt(core.getInput('retry-max-attempts', { required: false })) || 12;
     switch (true) {
       case specialCharacterWorkaround:
@@ -119,13 +120,13 @@ export async function run() {
     let webIdentityToken: string;
 
     //if the user wants to attempt to use existing credentials, check if we have some already
-    if (useExistingCredentials === 'true') {
+    if (useExistingCredentials) {
       const validCredentials = await areCredentialsValid(credentialsClient);
       if (validCredentials) {
-        core.info('Pre-existing credentials are valid. No need to generate new ones.');
+        core.notice('Pre-existing credentials are valid. No need to generate new ones.');
         return;
       }
-      core.info('No valid credentials exist. Running as normal.');
+      core.notice('No valid credentials exist. Running as normal.');
     }
 
     // If OIDC is being used, generate token

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,6 @@ export async function run() {
 
     //if the user wants to attempt to use existing credentials, check if we have some already
     if (useExistingCredentials === 'true') {
-      core.info('I set the use-existing-credentials value to true!');
       const validCredentials = await areCredentialsValid(credentialsClient);
       if (validCredentials) {
         core.info('Pre-existing credentials are valid. No need to generate new ones.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   retryAndBackoff,
   unsetCredentials,
   verifyKeys,
+  areCredentialsValid
 } from './helpers';
 
 const DEFAULT_ROLE_DURATION = 3600; // One hour (seconds)
@@ -60,6 +61,7 @@ export async function run() {
     const specialCharacterWorkaroundInput =
       core.getInput('special-characters-workaround', { required: false }) || 'false';
     const specialCharacterWorkaround = specialCharacterWorkaroundInput.toLowerCase() === 'true';
+    const useExistingCredentials = core.getInput('use-existing-credentials', { required: false}) || 'false';
     let maxRetries = Number.parseInt(core.getInput('retry-max-attempts', { required: false })) || 12;
     switch (true) {
       case specialCharacterWorkaround:
@@ -74,6 +76,8 @@ export async function run() {
     for (const managedSessionPolicy of managedSessionPoliciesInput) {
       managedSessionPolicies.push({ arn: managedSessionPolicy });
     }
+
+
 
     // Logic to decide whether to attempt to use OIDC or not
     const useGitHubOIDCProvider = () => {

--- a/test/mockinputs.test.ts
+++ b/test/mockinputs.test.ts
@@ -28,10 +28,9 @@ const inputs = {
     'aws-region': 'fake-region-1',
   },
   USE_EXISTING_CREDENTIALS_INPUTS: {
-    'role-to-assume': 'arn:aws:iam::111111111111:role/MY-ROLE',
     'aws-region': 'fake-region-1',
-    'special-characters-workaround': 'true',
     'use-existing-credentials': 'true',
+    'role-to-assume': 'arn:aws:iam::111111111111:role/MY-ROLE',
   }
 };
 
@@ -61,9 +60,6 @@ const outputs = {
   GET_CALLER_IDENTITY: {
     Account: '111111111111',
     Arn: 'arn:aws:iam::111111111111:role/MY-ROLE',
-  },
-  GET_CALLER_IDENTITY_NO_CREDS: {
-
   },
   FAKE_STS_ACCESS_KEY_ID: 'STSAWSACCESSKEYID',
   FAKE_STS_SECRET_ACCESS_KEY: 'STSAWSSECRETACCESSKEY',

--- a/test/mockinputs.test.ts
+++ b/test/mockinputs.test.ts
@@ -27,6 +27,12 @@ const inputs = {
     'role-chaining': 'true',
     'aws-region': 'fake-region-1',
   },
+  USE_EXISTING_CREDENTIALS_INPUTS: {
+    'role-to-assume': 'arn:aws:iam::111111111111:role/MY-ROLE',
+    'aws-region': 'fake-region-1',
+    'special-characters-workaround': 'true',
+    'use-existing-credentials': 'true',
+  }
 };
 
 const envs = {
@@ -55,6 +61,9 @@ const outputs = {
   GET_CALLER_IDENTITY: {
     Account: '111111111111',
     Arn: 'arn:aws:iam::111111111111:role/MY-ROLE',
+  },
+  GET_CALLER_IDENTITY_NO_CREDS: {
+
   },
   FAKE_STS_ACCESS_KEY_ID: 'STSAWSACCESSKEYID',
   FAKE_STS_SECRET_ACCESS_KEY: 'STSAWSSECRETACCESSKEY',


### PR DESCRIPTION
*Issue #, if available:* 
#1288

*Description of changes:*
Adds a new config option, use-existing-credentials. When set, the action will attempt to re-use existing credentials instead of fetching new credentials. If there are no existing credentials (or if the existing credentials are no longer valid), the action will proceed as normal.

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
