### PR TITLE
(docs) Removes duplicate word in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ for AWS API calls.
 
 ## Overview
 API calls to AWS need to be signed with credential information, so when you use
-one of the AWS SDKs or an AWS tool, you must provide it with AWS credentials and
+one of the AWS SDKs or an AWS tool, you must provide it with AWS credentials 
 and AWS region. One way to do that in GitHub Actions is to use a repository
 secret with IAM credentials, but this doesn't follow [AWS security
 guidelines](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html)


### PR DESCRIPTION
Minor fix to remove a duplicated `and`.

*Issue #, if available:*
N/A

*Description of changes:*
Removes duplicate `and` from the main README.md file. 

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
