### PR TITLE
fix: make sure action builds, also fix dependabot autoapprove

### DIFF
--- a/.github/workflows/dependabot-autoapprove.yml
+++ b/.github/workflows/dependabot-autoapprove.yml
@@ -1,8 +1,12 @@
 name: Dependabot auto-approve
-on: pull_request
+on: 
+  pull_request:
+  workflow_dispatch:
+
 permissions:
   pull-requests: write
   id-token: write
+  contents: read
 jobs:
   dependabot:
     runs-on: ubuntu-latest
@@ -17,7 +21,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-west-2
-          role-to-assume: ${{ secrets.SECRETS_AWS_PACKAGING_ROLE_TO_ASSUME }}
+          role-to-assume: arn:aws:iam::206735643321:role/ConfigureAwsCredentialsPackageRole
           role-duration-seconds: 900
       - name: Get bot user token
         uses: aws-actions/aws-secretsmanager-get-secrets@v2

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "lint": "biome check --error-on-warnings ./src",
     "package": "npm run build && ncc build --license THIRD-PARTY -o dist && ncc build src/cleanup/index.ts -o dist/cleanup && cpy dist/THIRD-PARTY . && del-cli dist/THIRD-PARTY",
-    "test": "npm run lint && vitest run"
+    "test": "npm run lint && vitest run && npm run build"
   },
   "author": {
     "name": "Amazon.com, Inc. or its affiliates",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

tries to run build as part of the tests to make sure that everything actually builds.
also, changes the dependabot-autoapprove action so that it should work.

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
