### PR TITLE
chore: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,13 @@ with the `role-external-id` input
 
 #### Session tagging and name
 The default session name is "GitHubActions", and you can modify it by specifying
-the desired name in `role-session-name`. The session will be tagged with the
+the desired name in `role-session-name`.
+
+_Note: you might find it helpful to set the `role-session-name` to `${{ github.run_id }}` 
+so as to clarify in audit logs which AWS actions were performed by which workflow 
+run._
+
+The session will be tagged with the
 following tags: (Refer to [GitHub's documentation for `GITHUB_` environment
 variable definitions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables))
 


### PR DESCRIPTION
update readme.md to provide a suggestion for altering the role-session-name for easier auditability

*Issue #, if available:* #1298

*Description of changes:*
Modifies readme to suggest setting `role-session-name` to `${{ github.run_id }}` to make auditing workflow runs easier.

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
