### PR TITLE
feat: support action inputs as environment variables

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,6 +7,36 @@ const MAX_TAG_VALUE_LENGTH = 256;
 const SANITIZATION_CHARACTER = '_';
 const SPECIAL_CHARS_REGEX = /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]+/;
 
+export function translateEnvVariables() {
+  const envVars = [
+    'AWS_REGION',
+    'ROLE_TO_ASSUME',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'WEB_IDENTITY_TOKEN_FILE',
+    'ROLE_CHAINING',
+    'AUDIENCE',
+    'HTTP_PROXY',
+    'MASK_AWS_ACCOUNT_ID',
+    'ROLE_DURATION_SECONDS',
+    'ROLE_EXTERNAL_ID',
+    'ROLE_SESSION_NAME',
+    'ROLE_SKIP_SESSION_TAGGING',
+    'INLINE_SESSION_POLICY',
+    'MANAGED_SESSION_POLICIES',
+    'OUTPUT_CREDENTIALS',
+    'UNSET_CURRENT_CREDENTIALS',
+    'DISABLE_RETRY',
+    'RETRY_MAX_ATTEMPTS',
+    'SPECIAL_CHARACTERS_WORKAROUND',
+    'USE_EXISTING_CREDENTIALS',
+  ];
+  for (const envVar of envVars) {
+    process.env[`INPUT_${envVar.replace(/_/g, '-').toUpperCase()}`] = process.env[envVar] || '';
+  }
+}
+
 // Configure the AWS CLI and AWS SDKs using environment variables and set them as secrets.
 // Setting the credentials as secrets masks them in Github Actions logs
 export function exportCredentials(creds?: Partial<Credentials>, outputCredentials?: boolean) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   retryAndBackoff,
   unsetCredentials,
   verifyKeys,
+  translateEnvVariables,
 } from './helpers';
 
 const DEFAULT_ROLE_DURATION = 3600; // One hour (seconds)
@@ -19,6 +20,7 @@ const REGION_REGEX = /^[a-z0-9-]+$/g;
 
 export async function run() {
   try {
+    translateEnvVariables();
     // Get inputs
     const AccessKeyId = core.getInput('aws-access-key-id', { required: false });
     const SecretAccessKey = core.getInput('aws-secret-access-key', {


### PR DESCRIPTION
*Issue #, if available:* #1335 

*Description of changes:* This commit support supplying action inputs as environment variables in the form of `ENVIRONMENT_VARIABLE` when the action input is `environment-variable`. If you wanted to set `role-to-assume` with an env var, you would set `ROLE_TO_ASSUME` in the environment.

Closes #1335 

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
