### PR TITLE
fix: role chaning on mulitple runs

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,9 +11,6 @@ export function translateEnvVariables() {
   const envVars = [
     'AWS_REGION',
     'ROLE_TO_ASSUME',
-    'AWS_ACCESS_KEY_ID',
-    'AWS_SECRET_ACCESS_KEY',
-    'AWS_SESSION_TOKEN',
     'WEB_IDENTITY_TOKEN_FILE',
     'ROLE_CHAINING',
     'AUDIENCE',


### PR DESCRIPTION
*Issue #, if available:* #1339

*Description of changes:*

We now consider environment variables as inputs, which breaks the inputs if this action has already put out environment variable, which you do on multiple runs. This commit excludes the three AWS credentials environment variable, restoring the previous behavior.

Closes #1339.