### PR TITLE
fix: ensure explicit inputs take precedence over environment variables

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -46744,7 +46744,8 @@ function translateEnvVariables() {
     ];
     for (const envVar of envVars) {
         if (process.env[envVar]) {
-            process.env[`INPUT_${envVar.replace(/_/g, '-')}`] = process.env[envVar];
+            const inputKey = `INPUT_${envVar.replace(/_/g, '-')}`;
+            process.env[inputKey] = process.env[inputKey] || process.env[envVar];
         }
     }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -306,7 +306,8 @@ function translateEnvVariables() {
     ];
     for (const envVar of envVars) {
         if (process.env[envVar]) {
-            process.env[`INPUT_${envVar.replace(/_/g, '-')}`] = process.env[envVar];
+            const inputKey = `INPUT_${envVar.replace(/_/g, '-')}`;
+            process.env[inputKey] = process.env[inputKey] || process.env[envVar];
         }
     }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,7 +31,8 @@ export function translateEnvVariables() {
   ];
   for (const envVar of envVars) {
     if (process.env[envVar]) {
-      process.env[`INPUT_${envVar.replace(/_/g, '-')}`] = process.env[envVar];
+      const inputKey = `INPUT_${envVar.replace(/_/g, '-')}`;
+      process.env[inputKey] = process.env[inputKey] || process.env[envVar];
     }
   }
 }


### PR DESCRIPTION
*Issue #1354*

*Description of changes:*
This PR fixes an issue where environment variables from previous action runs were overriding explicitly provided inputs when the action is called multiple times in a workflow.

Modified translateEnvVariables() to only set input variables if they haven't already been set by GitHub Actions from the with: parameters.

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
