### PR TITLE
fix: add missing `aws-expiration` output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,3 +84,5 @@ outputs:
     description: The AWS secret access key for the provided credentials
   aws-session-token:
     description: The AWS session token for the provided credentials
+  aws-expiration:
+    description: The AWS expiration time for the provided credentials


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The PR https://github.com/aws-actions/configure-aws-credentials/pull/1337 introduces `aws-expiration` to output. However, this new output is not yet documented in the GitHub Actions `action.yml`, which causes VSCode GitHub Actions extension IntelliSense to flag it as an invalid output:

![image](https://github.com/user-attachments/assets/006ced5c-1cd7-4686-b672-ed26db51907d)

This PR documents the missing output

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
