### PR TITLE
chore: update role-chaining example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ In this two-step example, the first step will use OIDC to assume the role
 example. Following that, a second step will use this role to assume a different
 role, `arn:aws:iam::987654321000:role/my-second-role`.
 
+Note that the trust relationship/trust policy of the second role must grant the permissions `sts:AssumeRole` and `sts:TagSession` to the first role. (Or, alternatively, the `TagSession` permission can be omitted if you are using the `role-skip-session-tagging: true` flag for the second step.)
+
 ### AssumeRole with static IAM credentials in repository secrets
 ```yaml
     - name: Configure AWS Credentials


### PR DESCRIPTION
*Issue #, if available:*
#1396 

*Description of changes:*
Updates the README to note that role-chaining requires you to either grant the `sts:TagSession` permission to the first role, or make the second call to the action with `role-skip-session-tagging: true`.

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
