### PR TITLE
feat: Support usage of AWS Profiles

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   aws-region:
     description: AWS Region, e.g. us-east-2
     required: true
+  aws-profile:
+    description: Name of the AWS profile to configure. When provided, credentials and config are written to ~/.aws/credentials and ~/.aws/config files instead of environment variables.
+    required: false
   role-to-assume:
     description: The Amazon Resource Name (ARN) of the role to assume. Use the provided credentials to assume an IAM role and configure the Actions environment with the assumed role credentials rather than with the provided credentials.
     required: false

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -43243,6 +43243,7 @@ function cleanup() {
             core.exportVariable('AWS_SESSION_TOKEN', '');
             core.exportVariable('AWS_DEFAULT_REGION', '');
             core.exportVariable('AWS_REGION', '');
+            core.exportVariable('AWS_PROFILE', '');
         }
         catch (error) {
             core.setFailed((0, helpers_1.errorMessage)(error));

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,14 @@
         "@actions/core": "^2.0.1",
         "@aws-sdk/client-sts": "^3.952.0",
         "@smithy/node-http-handler": "^4.4.5",
+        "ini": "^5.0.0",
         "proxy-agent": "^6.5.0"
       },
       "devDependencies": {
         "@aws-sdk/credential-provider-env": "^3.936.0",
         "@biomejs/biome": "2.3.9",
         "@smithy/property-provider": "^4.2.5",
+        "@types/ini": "^4.1.1",
         "@types/node": "^25.0.2",
         "@vercel/ncc": "^0.38.4",
         "@vitest/coverage-v8": "^3.2.4",
@@ -2626,6 +2628,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
@@ -2639,7 +2648,6 @@
       "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5267,6 +5275,13 @@
         "ini": "^1.3.2"
       }
     },
+    "node_modules/gitconfiglocal/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -5511,11 +5526,13 @@
       "license": "ISC"
     },
     "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.0.1",
@@ -7471,7 +7488,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7553,8 +7569,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -7679,7 +7694,6 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7796,7 +7810,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7810,7 +7823,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@aws-sdk/credential-provider-env": "^3.936.0",
     "@biomejs/biome": "2.3.9",
     "@smithy/property-provider": "^4.2.5",
+    "@types/ini": "^4.1.1",
     "@types/node": "^25.0.2",
     "@vercel/ncc": "^0.38.4",
     "@vitest/coverage-v8": "^3.2.4",
@@ -35,6 +36,7 @@
     "@actions/core": "^2.0.1",
     "@aws-sdk/client-sts": "^3.952.0",
     "@smithy/node-http-handler": "^4.4.5",
+    "ini": "^5.0.0",
     "proxy-agent": "^6.5.0"
   },
   "keywords": [

--- a/src/cleanup/index.ts
+++ b/src/cleanup/index.ts
@@ -25,6 +25,7 @@ export function cleanup() {
       core.exportVariable('AWS_SESSION_TOKEN', '');
       core.exportVariable('AWS_DEFAULT_REGION', '');
       core.exportVariable('AWS_REGION', '');
+      core.exportVariable('AWS_PROFILE', '');
     } catch (error) {
       core.setFailed(errorMessage(error));
     }

--- a/src/profileManager.ts
+++ b/src/profileManager.ts
@@ -1,0 +1,145 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as core from '@actions/core';
+import type { Credentials } from '@aws-sdk/client-sts';
+import * as ini from 'ini';
+
+interface ProfileFilePaths {
+  credentials: string;
+  config: string;
+}
+
+/**
+ * Get the file paths for AWS credentials and config files
+ * Respects AWS_SHARED_CREDENTIALS_FILE and AWS_CONFIG_FILE environment variables
+ */
+export function getProfileFilePaths(): ProfileFilePaths {
+  const credentialsPath = process.env.AWS_SHARED_CREDENTIALS_FILE || path.join(os.homedir(), '.aws', 'credentials');
+  const configPath = process.env.AWS_CONFIG_FILE || path.join(os.homedir(), '.aws', 'config');
+
+  return {
+    credentials: credentialsPath,
+    config: configPath,
+  };
+}
+
+/**
+ * Ensure the AWS directory exists with secure permissions
+ * Creates the directory with 700 permissions (rwx for owner only)
+ */
+export function ensureAwsDirectoryExists(filePath: string): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    core.debug(`Creating directory: ${dir}`);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+}
+
+/**
+ * Validate profile name format
+ * Profile names must be non-empty, contain no whitespace, brackets, or path separators
+ */
+export function validateProfileName(profileName: string): void {
+  if (!profileName || profileName.trim() === '') {
+    throw new Error('aws-profile must not be empty');
+  }
+
+  if (/\s/.test(profileName)) {
+    throw new Error('aws-profile must not contain whitespace');
+  }
+
+  // INI section names can't contain brackets
+  if (/[[\]]/.test(profileName)) {
+    throw new Error('aws-profile must not contain brackets');
+  }
+
+  // Prevent path traversal
+  if (profileName.includes('/') || profileName.includes('\\')) {
+    throw new Error('aws-profile must not contain path separators');
+  }
+}
+
+/**
+ * Merge a profile section into an INI file
+ * Reads existing file, updates the specified section, and writes back atomically
+ */
+export function mergeProfileSection(filePath: string, sectionName: string, data: Record<string, string>): void {
+  let existingContent: Record<string, Record<string, string>> = {};
+
+  // Read existing file if it exists
+  if (fs.existsSync(filePath)) {
+    core.debug(`Reading existing file: ${filePath}`);
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
+    existingContent = ini.parse(fileContent);
+  }
+
+  // Merge: update existing profile or add new one
+  existingContent[sectionName] = data;
+
+  // Atomic write: write to temp file, then rename
+  const tempFile = `${filePath}.tmp`;
+  const content = ini.stringify(existingContent);
+
+  core.debug(`Writing profile to ${filePath}`);
+  fs.writeFileSync(tempFile, content, { mode: 0o600 });
+  fs.renameSync(tempFile, filePath);
+}
+
+/**
+ * Write AWS profile files with credentials and configuration
+ * This is the main entry point for profile file operations
+ *
+ * @param profileName - Name of the AWS profile to configure
+ * @param credentials - AWS credentials (access key, secret key, session token)
+ * @param region - AWS region
+ */
+export function writeProfileFiles(profileName: string, credentials: Partial<Credentials>, region: string): void {
+  try {
+    // Validate profile name
+    validateProfileName(profileName);
+
+    const paths = getProfileFilePaths();
+
+    // Ensure .aws directory exists
+    ensureAwsDirectoryExists(paths.credentials);
+    ensureAwsDirectoryExists(paths.config);
+
+    // Prepare credentials data
+    const credentialsData: Record<string, string> = {};
+    if (credentials.AccessKeyId) {
+      credentialsData.aws_access_key_id = credentials.AccessKeyId;
+    }
+    if (credentials.SecretAccessKey) {
+      credentialsData.aws_secret_access_key = credentials.SecretAccessKey;
+    }
+    if (credentials.SessionToken) {
+      credentialsData.aws_session_token = credentials.SessionToken;
+    }
+
+    // Credentials file uses [profileName] syntax
+    const credsSectionName = profileName;
+
+    // Config file uses [profile profileName] syntax, except for 'default'
+    const configSectionName = profileName === 'default' ? 'default' : `profile ${profileName}`;
+
+    // Prepare config data
+    const configData: Record<string, string> = {
+      region: region,
+    };
+
+    // Write to credentials file
+    core.info(`Writing credentials to profile: ${profileName}`);
+    mergeProfileSection(paths.credentials, credsSectionName, credentialsData);
+
+    // Write to config file
+    core.info(`Writing config to profile: ${profileName}`);
+    mergeProfileSection(paths.config, configSectionName, configData);
+
+    core.info(`✓ Successfully configured AWS profile: ${profileName}`);
+  } catch (error) {
+    throw new Error(
+      `Failed to write AWS profile '${profileName}': ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -31,12 +31,13 @@ describe('Configure AWS Credentials cleanup', {}, () => {
   it('replaces AWS credential and region environment variables with empty strings', {}, () => {
     cleanup();
     expect(core.setFailed).toHaveBeenCalledTimes(0);
-    expect(core.exportVariable).toHaveBeenCalledTimes(5);
+    expect(core.exportVariable).toHaveBeenCalledTimes(6);
     expect(core.exportVariable).toHaveBeenCalledWith('AWS_ACCESS_KEY_ID', '');
     expect(core.exportVariable).toHaveBeenCalledWith('AWS_SECRET_ACCESS_KEY', '');
     expect(core.exportVariable).toHaveBeenCalledWith('AWS_SESSION_TOKEN', '');
     expect(core.exportVariable).toHaveBeenCalledWith('AWS_DEFAULT_REGION', '');
     expect(core.exportVariable).toHaveBeenCalledWith('AWS_REGION', '');
+    expect(core.exportVariable).toHaveBeenCalledWith('AWS_PROFILE', '');
   });
   it('handles errors', {}, () => {
     vi.spyOn(core, 'exportVariable').mockImplementationOnce(() => {

--- a/test/profileManager.test.ts
+++ b/test/profileManager.test.ts
@@ -1,0 +1,342 @@
+import * as core from '@actions/core';
+import { fs, vol } from 'memfs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as ini from 'ini';
+import {
+  ensureAwsDirectoryExists,
+  getProfileFilePaths,
+  mergeProfileSection,
+  validateProfileName,
+  writeProfileFiles,
+} from '../src/profileManager';
+
+describe('Profile Manager', {}, () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mock('node:fs');
+    vol.reset();
+    vi.spyOn(core, 'debug').mockImplementation(() => {});
+    vi.spyOn(core, 'info').mockImplementation(() => {});
+  });
+
+  describe('validateProfileName', {}, () => {
+    it('accepts valid profile names', {}, () => {
+      expect(() => validateProfileName('dev')).not.toThrow();
+      expect(() => validateProfileName('production')).not.toThrow();
+      expect(() => validateProfileName('my-profile-123')).not.toThrow();
+      expect(() => validateProfileName('default')).not.toThrow();
+    });
+
+    it('rejects empty profile names', {}, () => {
+      expect(() => validateProfileName('')).toThrow('aws-profile must not be empty');
+      expect(() => validateProfileName('   ')).toThrow('aws-profile must not be empty');
+    });
+
+    it('rejects profile names with whitespace', {}, () => {
+      expect(() => validateProfileName('my profile')).toThrow('aws-profile must not contain whitespace');
+      expect(() => validateProfileName('dev\ntest')).toThrow('aws-profile must not contain whitespace');
+      expect(() => validateProfileName('prod\tenv')).toThrow('aws-profile must not contain whitespace');
+    });
+
+    it('rejects profile names with brackets', {}, () => {
+      expect(() => validateProfileName('dev[test]')).toThrow('aws-profile must not contain brackets');
+      expect(() => validateProfileName('[profile]')).toThrow('aws-profile must not contain brackets');
+    });
+
+    it('rejects profile names with path separators', {}, () => {
+      expect(() => validateProfileName('dev/test')).toThrow('aws-profile must not contain path separators');
+      expect(() => validateProfileName('dev\\test')).toThrow('aws-profile must not contain path separators');
+      expect(() => validateProfileName('../etc/passwd')).toThrow('aws-profile must not contain path separators');
+    });
+  });
+
+  describe('getProfileFilePaths', {}, () => {
+    it('returns default paths when env vars not set', {}, () => {
+      delete process.env.AWS_SHARED_CREDENTIALS_FILE;
+      delete process.env.AWS_CONFIG_FILE;
+
+      const paths = getProfileFilePaths();
+
+      expect(paths.credentials).toMatch(/\.aws\/credentials$/);
+      expect(paths.config).toMatch(/\.aws\/config$/);
+    });
+
+    it('respects AWS_SHARED_CREDENTIALS_FILE env var', {}, () => {
+      process.env.AWS_SHARED_CREDENTIALS_FILE = '/custom/path/credentials';
+      process.env.AWS_CONFIG_FILE = '/custom/path/config';
+
+      const paths = getProfileFilePaths();
+
+      expect(paths.credentials).toBe('/custom/path/credentials');
+      expect(paths.config).toBe('/custom/path/config');
+    });
+  });
+
+  describe('ensureAwsDirectoryExists', {}, () => {
+    it('creates directory if it does not exist', {}, () => {
+      const filePath = '/home/runner/.aws/credentials';
+
+      ensureAwsDirectoryExists(filePath);
+
+      expect(fs.existsSync('/home/runner/.aws')).toBe(true);
+    });
+
+    it('does not error if directory already exists', {}, () => {
+      const filePath = '/home/runner/.aws/credentials';
+
+      fs.mkdirSync('/home/runner/.aws', { recursive: true });
+
+      expect(() => ensureAwsDirectoryExists(filePath)).not.toThrow();
+    });
+
+    it('creates nested directories', {}, () => {
+      const filePath = '/home/runner/custom/path/.aws/credentials';
+
+      ensureAwsDirectoryExists(filePath);
+
+      expect(fs.existsSync('/home/runner/custom/path/.aws')).toBe(true);
+    });
+  });
+
+  describe('mergeProfileSection', {}, () => {
+    it('creates new file with profile section', {}, () => {
+      const filePath = '/home/runner/.aws/credentials';
+      fs.mkdirSync('/home/runner/.aws', { recursive: true });
+
+      mergeProfileSection(filePath, 'dev', {
+        aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE',
+        aws_secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      });
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const parsed = ini.parse(content);
+
+      expect(parsed.dev).toBeDefined();
+      expect(parsed.dev.aws_access_key_id).toBe('AKIAIOSFODNN7EXAMPLE');
+      expect(parsed.dev.aws_secret_access_key).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+    });
+
+    it('merges with existing profiles', {}, () => {
+      const filePath = '/home/runner/.aws/credentials';
+      fs.mkdirSync('/home/runner/.aws', { recursive: true });
+
+      // Create initial profile
+      mergeProfileSection(filePath, 'dev', {
+        aws_access_key_id: 'AKIAIOSFODNN7EXAMPLE',
+        aws_secret_access_key: 'devSecretKey',
+      });
+
+      // Add second profile
+      mergeProfileSection(filePath, 'prod', {
+        aws_access_key_id: 'AKIAPRODEXAMPLE',
+        aws_secret_access_key: 'prodSecretKey',
+      });
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const parsed = ini.parse(content);
+
+      expect(parsed.dev).toBeDefined();
+      expect(parsed.dev.aws_access_key_id).toBe('AKIAIOSFODNN7EXAMPLE');
+      expect(parsed.prod).toBeDefined();
+      expect(parsed.prod.aws_access_key_id).toBe('AKIAPRODEXAMPLE');
+    });
+
+    it('overwrites existing profile with same name', {}, () => {
+      const filePath = '/home/runner/.aws/credentials';
+      fs.mkdirSync('/home/runner/.aws', { recursive: true });
+
+      // Create initial profile
+      mergeProfileSection(filePath, 'dev', {
+        aws_access_key_id: 'OLD_KEY',
+        aws_secret_access_key: 'oldSecretKey',
+      });
+
+      // Overwrite with new credentials
+      mergeProfileSection(filePath, 'dev', {
+        aws_access_key_id: 'NEW_KEY',
+        aws_secret_access_key: 'newSecretKey',
+        aws_session_token: 'sessionToken',
+      });
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const parsed = ini.parse(content);
+
+      expect(parsed.dev.aws_access_key_id).toBe('NEW_KEY');
+      expect(parsed.dev.aws_secret_access_key).toBe('newSecretKey');
+      expect(parsed.dev.aws_session_token).toBe('sessionToken');
+    });
+  });
+
+  describe('writeProfileFiles', {}, () => {
+    beforeEach(() => {
+      delete process.env.AWS_SHARED_CREDENTIALS_FILE;
+      delete process.env.AWS_CONFIG_FILE;
+    });
+
+    it('writes credentials and config for new profile', {}, () => {
+      writeProfileFiles(
+        'dev',
+        {
+          AccessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+          SecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+          SessionToken: 'FwoGZXIvYXdzEBYaDEXAMPLE',
+        },
+        'us-east-1',
+      );
+
+      // Check credentials file
+      const credsPath = getProfileFilePaths().credentials;
+      const credContent = fs.readFileSync(credsPath, 'utf-8');
+      const credParsed = ini.parse(credContent);
+
+      expect(credParsed.dev).toBeDefined();
+      expect(credParsed.dev.aws_access_key_id).toBe('AKIAIOSFODNN7EXAMPLE');
+      expect(credParsed.dev.aws_secret_access_key).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+      expect(credParsed.dev.aws_session_token).toBe('FwoGZXIvYXdzEBYaDEXAMPLE');
+
+      // Check config file
+      const configPath = getProfileFilePaths().config;
+      const configContent = fs.readFileSync(configPath, 'utf-8');
+      const configParsed = ini.parse(configContent);
+
+      expect(configParsed['profile dev']).toBeDefined();
+      expect(configParsed['profile dev'].region).toBe('us-east-1');
+    });
+
+    it('uses correct section naming for default profile', {}, () => {
+      writeProfileFiles(
+        'default',
+        {
+          AccessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+          SecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        },
+        'us-west-2',
+      );
+
+      // Check credentials file uses [default]
+      const credsPath = getProfileFilePaths().credentials;
+      const credContent = fs.readFileSync(credsPath, 'utf-8');
+      const credParsed = ini.parse(credContent);
+
+      expect(credParsed.default).toBeDefined();
+      expect(credParsed['profile default']).toBeUndefined();
+
+      // Check config file uses [default] (not [profile default])
+      const configPath = getProfileFilePaths().config;
+      const configContent = fs.readFileSync(configPath, 'utf-8');
+      const configParsed = ini.parse(configContent);
+
+      expect(configParsed.default).toBeDefined();
+      expect(configParsed['profile default']).toBeUndefined();
+    });
+
+    it('supports multiple profiles', {}, () => {
+      // Write first profile
+      writeProfileFiles(
+        'dev',
+        {
+          AccessKeyId: 'AKIADEV',
+          SecretAccessKey: 'devSecret',
+        },
+        'us-east-1',
+      );
+
+      // Write second profile
+      writeProfileFiles(
+        'prod',
+        {
+          AccessKeyId: 'AKIAPROD',
+          SecretAccessKey: 'prodSecret',
+          SessionToken: 'prodToken',
+        },
+        'us-west-2',
+      );
+
+      // Verify both profiles exist
+      const credsPath = getProfileFilePaths().credentials;
+      const credContent = fs.readFileSync(credsPath, 'utf-8');
+      const credParsed = ini.parse(credContent);
+
+      expect(credParsed.dev).toBeDefined();
+      expect(credParsed.prod).toBeDefined();
+      expect(credParsed.dev.aws_access_key_id).toBe('AKIADEV');
+      expect(credParsed.prod.aws_access_key_id).toBe('AKIAPROD');
+    });
+
+    it('handles credentials without session token', {}, () => {
+      writeProfileFiles(
+        'dev',
+        {
+          AccessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+          SecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        },
+        'us-east-1',
+      );
+
+      const credsPath = getProfileFilePaths().credentials;
+      const credContent = fs.readFileSync(credsPath, 'utf-8');
+      const credParsed = ini.parse(credContent);
+
+      expect(credParsed.dev.aws_access_key_id).toBe('AKIAIOSFODNN7EXAMPLE');
+      expect(credParsed.dev.aws_secret_access_key).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+      expect(credParsed.dev.aws_session_token).toBeUndefined();
+    });
+
+    it('throws error for invalid profile name', {}, () => {
+      expect(() =>
+        writeProfileFiles(
+          'invalid profile',
+          {
+            AccessKeyId: 'AKIA',
+            SecretAccessKey: 'secret',
+          },
+          'us-east-1',
+        ),
+      ).toThrow('Failed to write AWS profile');
+      expect(() =>
+        writeProfileFiles(
+          'invalid profile',
+          {
+            AccessKeyId: 'AKIA',
+            SecretAccessKey: 'secret',
+          },
+          'us-east-1',
+        ),
+      ).toThrow('whitespace');
+    });
+
+    it('respects custom file paths from env vars', {}, () => {
+      process.env.AWS_SHARED_CREDENTIALS_FILE = '/custom/credentials';
+      process.env.AWS_CONFIG_FILE = '/custom/config';
+
+      fs.mkdirSync('/custom', { recursive: true });
+
+      writeProfileFiles(
+        'dev',
+        {
+          AccessKeyId: 'AKIA',
+          SecretAccessKey: 'secret',
+        },
+        'us-east-1',
+      );
+
+      expect(fs.existsSync('/custom/credentials')).toBe(true);
+      expect(fs.existsSync('/custom/config')).toBe(true);
+    });
+
+    it('logs info messages', {}, () => {
+      writeProfileFiles(
+        'dev',
+        {
+          AccessKeyId: 'AKIA',
+          SecretAccessKey: 'secret',
+        },
+        'us-east-1',
+      );
+
+      expect(core.info).toHaveBeenCalledWith('Writing credentials to profile: dev');
+      expect(core.info).toHaveBeenCalledWith('Writing config to profile: dev');
+      expect(core.info).toHaveBeenCalledWith('✓ Successfully configured AWS profile: dev');
+    });
+  });
+});


### PR DESCRIPTION
*Issue #, if available:* #1586 and #112 

*Description of changes:*

This feature adds support for named AWS profiles to the configure-aws-credentials GitHub Action, enabling users to configure multiple AWS profiles in a single workflow and write credentials to standard AWS configuration files (~/.aws/credentials and ~/.aws/config) instead of only exporting them as environment variables.

Motivation

Previously, the action only supported exporting credentials as environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN), which created several limitations:

  1. No multi-profile support: Impossible to configure multiple AWS accounts/roles in a single workflow job
  2. Tool compatibility issues: Many tools (Terraform, AWS CDK, multi-account scripts) expect credentials in ~/.aws/credentials and ~/.aws/config files
  3. Profile switching: No way to easily switch between different AWS contexts in a single job
  4. Standard AWS CLI workflows: Users couldn't use aws --profile <name> commands

Solution

Add an optional aws-profile input that, when provided, writes credentials to AWS configuration files in standard INI format, allowing natural integration with AWS CLI, SDKs, and infrastructure-as-code tools.

---

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
