### PR TITLE
fix: correct outputs for role chaining

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36,9 +36,10 @@ class CredentialsClient {
                 httpAgent: handler,
             });
         }
+        this.roleChaining = props.roleChaining;
     }
     get stsClient() {
-        if (!this._stsClient) {
+        if (!this._stsClient || this.roleChaining) {
             const config = { customUserAgent: USER_AGENT };
             if (this.region !== undefined)
                 config.region = this.region;
@@ -756,7 +757,10 @@ async function run() {
         }
         (0, helpers_1.exportRegion)(region, outputEnvCredentials);
         // Instantiate credentials client
-        const clientProps = { region };
+        const clientProps = {
+            region,
+            roleChaining,
+        };
         if (proxyServer)
             clientProps.proxyServer = proxyServer;
         if (noProxy)

--- a/src/CredentialsClient.ts
+++ b/src/CredentialsClient.ts
@@ -12,12 +12,14 @@ export interface CredentialsClientProps {
   region?: string;
   proxyServer?: string;
   noProxy?: string;
+  roleChaining: boolean;
 }
 
 export class CredentialsClient {
   public region?: string;
   private _stsClient?: STSClient;
   private readonly requestHandler?: NodeHttpHandler;
+  private roleChaining?: boolean;
 
   constructor(props: CredentialsClientProps) {
     if (props.region !== undefined) {
@@ -39,10 +41,11 @@ export class CredentialsClient {
         httpAgent: handler,
       });
     }
+    this.roleChaining = props.roleChaining;
   }
 
   public get stsClient(): STSClient {
-    if (!this._stsClient) {
+    if (!this._stsClient || this.roleChaining) {
       const config = { customUserAgent: USER_AGENT } as {
         customUserAgent: string;
         region?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,10 @@ export async function run() {
     exportRegion(region, outputEnvCredentials);
 
     // Instantiate credentials client
-    const clientProps: { region: string; proxyServer?: string; noProxy?: string } = { region };
+    const clientProps: { region: string; proxyServer?: string; noProxy?: string; roleChaining: boolean } = {
+      region,
+      roleChaining,
+    };
     if (proxyServer) clientProps.proxyServer = proxyServer;
     if (noProxy) clientProps.noProxy = noProxy;
     const credentialsClient = new CredentialsClient(clientProps);


### PR DESCRIPTION
*Issue #, if available:* #1578, #911

*Description of changes:*
re-instantiates the STSClient if role chaining is enabled, causing the step outputs `aws-account-id` and `authenticated-arn` to be correct.

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
