### PR TITLE
feat: Immutable-ID sub format example

### DIFF
--- a/examples/federated-setup/github-actions-oidc-federation-and-role.yml
+++ b/examples/federated-setup/github-actions-oidc-federation-and-role.yml
@@ -8,9 +8,25 @@ Parameters:
     Type: String
     Description: This is the root organization or personal account where repos are stored (Case Sensitive)
 
+  GitHubOrganizationId:
+    Type: String
+    Description: >-
+      Numeric GitHub organization (or user) ID, embedded in the OIDC sub claim
+      of repos created after GitHub's immutable-ID rollout. Find it with:
+      gh api /orgs/<org> --jq .id (use * to match any, at the cost of rename protection)
+    Default: "*"
+
   RepositoryName:
     Type: String
     Description: The repo(s) these roles will have access to. (Use * for all org or personal repos)
+    Default: "*"
+
+  RepositoryId:
+    Type: String
+    Description: >-
+      Numeric GitHub repository ID, embedded in the OIDC sub claim of repos
+      created after GitHub's immutable-ID rollout. Find it with:
+      gh api /repos/<org>/<repo> --jq .id (use * to match by repo name only)
     Default: "*"
 
   BranchName:
@@ -64,8 +80,16 @@ Resources:
                 - !Ref IdpGitHubOidc
                 - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
             Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: "sts.amazonaws.com"
               StringLike:
-                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrganization}/${RepositoryName}:ref:refs/heads/${BranchName}
+                token.actions.githubusercontent.com:sub:
+                  # Classic sub format (repos created before GitHub's
+                  # immutable-ID rollout on July 15, 2026)
+                  - !Sub repo:${GitHubOrganization}/${RepositoryName}:ref:refs/heads/${BranchName}
+                  # Immutable-ID sub format (repos created after the rollout):
+                  # repo:<org>@<org-id>/<repo>@<repo-id>:ref:refs/heads/<branch>
+                  - !Sub repo:${GitHubOrganization}@${GitHubOrganizationId}/${RepositoryName}@${RepositoryId}:ref:refs/heads/${BranchName}
       ManagedPolicyArns:
         ## edit the managed policy to give least privileges
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

GitHub changed the default OIDC subject (`sub`) claim format for newly created
repositories (enforced for all new repos and renames as of July 15, 2026). New
repos now present subjects with immutable numeric IDs embedded after the org
and repo slugs:

    repo:my-org@84790634/my-repo@1304267049:ref:refs/heads/main

instead of the classic format this template's trust condition was built for:

    repo:my-org/my-repo:ref:refs/heads/main

Because the trust policy pattern `repo:<org>/<repo>:ref:refs/heads/<branch>`
requires a `/` immediately after the org slug, tokens from any newly created
repo fail role assumption with:

    Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity

This PR updates the template to trust **both** formats, so existing repos keep
working and new repos stop failing.

Reference: https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/

## Changes

- **`sub` condition is now a list** with two `StringLike` patterns: the
  existing classic pattern (unchanged) and a new immutable-ID pattern
  (`repo:<org>@<org-id>/<repo>@<repo-id>:ref:refs/heads/<branch>`).
- **New parameters** `GitHubOrganizationId` and `RepositoryId` (both default
  `*`). Defaults keep the template deployable without looking up IDs; pinning
  them gives rename-proof trust, since numeric IDs cannot be re-registered the
  way org/repo slugs can. Look them up with:
  - `gh api /orgs/<org> --jq .id`
  - `gh api /repos/<org>/<repo> --jq .id`
- **Added `aud` condition** (`StringEquals: sts.amazonaws.com`). The trust
  previously accepted tokens minted for any audience; this pins it to the
  audience `aws-actions/configure-aws-credentials` sends by default.

## Backward compatibility

- Existing repos on the classic format continue to match via the first
  pattern — no workflow changes required.
- Existing stacks can be updated in place; the role is modified, not replaced.
- The only behavioral tightening is the new `aud` condition, which is a no-op
  for standard `configure-aws-credentials` usage.

## Not changed

- The `:ref:refs/heads/<branch>` suffix still means jobs bound to a GitHub
  `environment:` will not match (their subjects end in `:environment:<name>`).
  This is pre-existing behavior, unchanged by this PR.
- `ClientIdList` and `ThumbprintList` on the provider are untouched (AWS now
  validates GitHub's OIDC endpoint against trusted root CAs and ignores the
  thumbprint).


---

- [x] Have you followed the guidelines in our
      [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
