### PR TITLE
fix: PackedPolicyTooLarge detection in STS tags

### DIFF
--- a/src/assumeRole.ts
+++ b/src/assumeRole.ts
@@ -2,11 +2,7 @@ import assert from 'node:assert';
 import path from 'node:path';
 import * as core from '@actions/core';
 import type { AssumeRoleCommandInput, STSClient, Tag } from '@aws-sdk/client-sts';
-import {
-  AssumeRoleCommand,
-  AssumeRoleWithWebIdentityCommand,
-  PackedPolicyTooLargeException,
-} from '@aws-sdk/client-sts';
+import { AssumeRoleCommand, AssumeRoleWithWebIdentityCommand } from '@aws-sdk/client-sts';
 import type { CredentialsClient } from './CredentialsClient';
 import { errorMessage, isDefined, readFileUtf8, sanitizeGitHubVariables } from './helpers';
 
@@ -65,7 +61,7 @@ async function assumeRoleWithCredentials(params: AssumeRoleCommandInput, client:
     const creds = await client.send(new AssumeRoleCommand({ ...params }));
     return creds;
   } catch (error) {
-    if (error instanceof PackedPolicyTooLargeException) {
+    if ((error as { name?: string })?.name === 'PackedPolicyTooLargeException') {
       core.info('Session tag size is too large; dropping droppable tags and retrying.');
       const droppableKeys = new Set(DROPPABLE_TAG_SOURCES.map((s) => s.key));
       params.Tags = params.Tags?.filter((tag) => !droppableKeys.has(tag.Key ?? ''));

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,6 @@ import {
   AssumeRoleCommand,
   AssumeRoleWithWebIdentityCommand,
   GetCallerIdentityCommand,
-  PackedPolicyTooLargeException,
   STSClient,
 } from '@aws-sdk/client-sts';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -331,10 +330,11 @@ describe('Configure AWS Credentials', {}, () => {
     });
     it('drops droppable tags and retries on PackedPolicyTooLargeException', {}, async () => {
       vi.mocked(core.getInput).mockImplementation(mocks.getInput(mocks.IAM_ASSUMEROLE_INPUTS));
-      mockedSTSClient
-        .on(AssumeRoleCommand)
-        .rejectsOnce(new PackedPolicyTooLargeException({ message: 'too large', $metadata: {} }))
-        .resolvesOnce(mocks.outputs.STS_CREDENTIALS);
+      // Reject with a plain error carrying only the `name`, NOT an instance of the SDK class. This
+      // mirrors the bundled action, where the error can be deserialized by a second, non-identical
+      // copy of PackedPolicyTooLargeException so `instanceof` fails; the recovery must key off `name`.
+      const packedPolicyError = Object.assign(new Error('too large'), { name: 'PackedPolicyTooLargeException' });
+      mockedSTSClient.on(AssumeRoleCommand).rejectsOnce(packedPolicyError).resolvesOnce(mocks.outputs.STS_CREDENTIALS);
       await run();
       expect(core.info).toHaveBeenCalledWith('Session tag size is too large; dropping droppable tags and retrying.');
       const retryInput = mockedSTSClient.commandCalls(AssumeRoleCommand)[1].args[0].input;


### PR DESCRIPTION
Closes #1898.

Due to a bundling, checking for `error instanceof
PackedPolicyTooLargeException` fails. Instead we need to explicitly check for `error.name`.