### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Authenticate to AWS in GitHub Actions (and others)! Works especially well with
              "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
              "token.actions.githubusercontent.com:sub": "repo:<GITHUB_ORG>@<ORG_ID>/<GITHUB_REPOSITORY>@<REPO_ID>:ref:refs/heads/<GITHUB_BRANCH>"
            }
+           // For personal repo, use:
+           // "StringLike": {
+           //   "token.actions.githubusercontent.com:sub": "repo:<GITHUB_USERNAME>*/<GITHUB_REPOSITORY>*:ref:refs/heads/<GITHUB_BRANCH>" 
+           // } 
          }
        }
      ]


### PR DESCRIPTION
For personal repos, there's no org ID and finding the repo ID is unnecessarily difficult. 
Here's a simpler way:

```json5
// GitHub OIDC Trust Policy
"StringLike": {
    "token.actions.githubusercontent.com:sub": "repo:<GITHUB_USERNAME>*/<GITHUB_REPOSITORY>*" 
} 
```

- [x] Have you followed the guidelines in our
      [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
