### PR TITLE
fix: avoid sleeping after last retry

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74839,17 +74839,18 @@ async function retryAndBackoff(fn, isRetryable, maxRetries = 12, retries = 0, ba
       debug(`retryAndBackoff: error is not retryable: ${errorMessage(err)}`);
       throw err;
     }
-    const delay = Math.random() * (2 ** retries * base);
     const nextRetry = retries + 1;
     const opName = label ? ` ${label}` : "";
+    if (nextRetry >= maxRetries) {
+      info(`Retry${opName}: attempt ${nextRetry} of ${maxRetries} failed: ${errorMessage(err)}.`);
+      info(`Retry${opName}: reached max retries (${maxRetries}); giving up.`);
+      throw err;
+    }
+    const delay = Math.random() * (2 ** retries * base);
     info(
       `Retry${opName}: attempt ${nextRetry} of ${maxRetries} failed: ${errorMessage(err)}. Retrying after ${Math.floor(delay)}ms.`
     );
     await sleep2(delay);
-    if (nextRetry >= maxRetries) {
-      info(`Retry${opName}: reached max retries (${maxRetries}); giving up.`);
-      throw err;
-    }
     return await retryAndBackoff(fn, isRetryable, maxRetries, nextRetry, base, label);
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -250,10 +250,17 @@ export async function retryAndBackoff<T>(
       core.debug(`retryAndBackoff: error is not retryable: ${errorMessage(err)}`);
       throw err;
     }
-    // It's retryable, so sleep and retry.
-    const delay = Math.random() * (2 ** retries * base);
+    // It's retryable, so sleep and retry, unless we've exhausted our retries.
     const nextRetry = retries + 1;
     const opName = label ? ` ${label}` : '';
+
+    if (nextRetry >= maxRetries) {
+      core.info(`Retry${opName}: attempt ${nextRetry} of ${maxRetries} failed: ${errorMessage(err)}.`);
+      core.info(`Retry${opName}: reached max retries (${maxRetries}); giving up.`);
+      throw err;
+    }
+
+    const delay = Math.random() * (2 ** retries * base);
 
     core.info(
       `Retry${opName}: attempt ${nextRetry} of ${maxRetries} failed: ${errorMessage(err)}. ` +
@@ -261,11 +268,6 @@ export async function retryAndBackoff<T>(
     );
 
     await sleep(delay);
-
-    if (nextRetry >= maxRetries) {
-      core.info(`Retry${opName}: reached max retries (${maxRetries}); giving up.`);
-      throw err;
-    }
 
     return await retryAndBackoff(fn, isRetryable, maxRetries, nextRetry, base, label);
   }

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -53,7 +53,7 @@ describe('Configure AWS Credentials helpers', {}, () => {
     // Only slept between attempts, never after the last one.
     expect(sleepSpy).toHaveBeenCalledTimes(2);
     expect(core.info).toHaveBeenCalledWith(expect.stringContaining('Retry TestOp: attempt 3 of 3 failed'));
-    expect(core.info).not.toHaveBeenCalledWith(expect.stringContaining('attempt 3 of 3 failed: Error: persistent. Retrying after'));
+    expect(core.info).not.toHaveBeenCalledWith(expect.stringContaining('attempt 3 of 3 failed: persistent. Retrying after'));
     helpers.reset();
   });
   it('retries without a label (backward compat)', {}, async () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -44,6 +44,18 @@ describe('Configure AWS Credentials helpers', {}, () => {
     expect(core.info).toHaveBeenCalledWith(expect.stringContaining('Retry TestOp: reached max retries (2)'));
     helpers.reset();
   });
+  it('does not sleep or log a retry message on the final failed attempt', {}, async () => {
+    const sleepSpy = vi.fn().mockResolvedValue(undefined);
+    helpers.withsleep(sleepSpy);
+    const fn = vi.fn().mockRejectedValue(new Error('persistent'));
+    await expect(helpers.retryAndBackoff(fn, true, 3, 0, 50, 'TestOp')).rejects.toThrow('persistent');
+    expect(fn).toHaveBeenCalledTimes(3);
+    // Only slept between attempts, never after the last one.
+    expect(sleepSpy).toHaveBeenCalledTimes(2);
+    expect(core.info).toHaveBeenCalledWith(expect.stringContaining('Retry TestOp: attempt 3 of 3 failed'));
+    expect(core.info).not.toHaveBeenCalledWith(expect.stringContaining('attempt 3 of 3 failed: Error: persistent. Retrying after'));
+    helpers.reset();
+  });
   it('retries without a label (backward compat)', {}, async () => {
     helpers.withsleep(() => Promise.resolve());
     const fn = vi.fn().mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce('ok');


### PR DESCRIPTION
_Description of changes:_

- Avoid sleeping after a final retry attempt.
- Avoid logging a message about a retry that will not happen.

Before this change, you would see output like this from the action:

```text
Assuming role with OIDC
Retry AssumeRole: attempt 1 of 12 failed: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity. Retrying after 41ms.
Assuming role with OIDC
Retry AssumeRole: attempt 2 of 12 failed: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity. Retrying after 12ms.

<SNIP>

Retry AssumeRole: attempt 11 of 12 failed: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity. Retrying after 38915ms.
Assuming role with OIDC
Retry AssumeRole: attempt 12 of 12 failed: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity. Retrying after 57664ms.
Retry AssumeRole: reached max retries (12); giving up.
```

After this change, the output would instead be:

```diff
Retry AssumeRole: attempt 11 of 12 failed: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity. Retrying after 38915ms.
Assuming role with OIDC
- Retry AssumeRole: attempt 12 of 12 failed: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity. Retrying after 57664ms.
+ Retry AssumeRole: attempt 12 of 12 failed: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity.
Retry AssumeRole: reached max retries (12); giving up.
```

This avoids `retryAndBackoff` waiting for a minute before returning when it is not going to do any further attempts.

---

- [x] Have you followed the guidelines in our
      [Contributing guide?](https://github.com/aws-actions/configure-aws-credentials/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
